### PR TITLE
Register composer installer on init

### DIFF
--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -14,7 +14,7 @@ class Installer extends BaseInstaller {
 	 * @return bool
 	 */
 	public function supports( $type ) {
-		return $type === 'wordpress-plugin';
+		return in_array( $type, [ 'wordpress-plugin', 'wordpress-muplugin' ], true );
 	}
 
 	public function getInstallPath( PackageInterface $package, $framework_type = '' ) {

--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -6,8 +6,18 @@ use Composer\Installers\Installer as BaseInstaller;
 use Composer\Package\PackageInterface;
 
 class Installer extends BaseInstaller {
-	public function getInstallPath( PackageInterface $package, $framework_type = '' ) {
 
+	/**
+	 * Check if the installer supports a given type.
+	 *
+	 * @param string $type
+	 * @return bool
+	 */
+	public function supports( $type ) {
+		return $type === 'wordpress-plugin';
+	}
+
+	public function getInstallPath( PackageInterface $package, $framework_type = '' ) {
 		/**
 		 * Allow specific wordpress-plugin packages to skip the wordpress-plugin
 		 * installer. We use this to stop plugins that are bundled with modules are

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -19,6 +19,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		$this->composer = $composer;
 		$this->io = $io;
 
+		$installer = new Installer( $this->io, $this->composer );
+		$this->composer->getInstallationManager()->addInstaller( $installer );
 	}
 
 	/**
@@ -36,7 +38,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	 * Register the installer on the `init` hook.
 	 *
 	 * We want to register later than the composer-installers installer
-	 * as the last-added installer takes precedence.
+	 * as the last-added installer takes precedence. This event only runs
+	 * on update (if this plugin is already present), so we have to add it
+	 * in addition ot the $this->activate() method.
 	 */
 	public function init() {
 		$installer = new Installer( $this->io, $this->composer );

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -40,7 +40,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	 * We want to register later than the composer-installers installer
 	 * as the last-added installer takes precedence. This event only runs
 	 * on update (if this plugin is already present), so we have to add it
-	 * in addition ot the $this->activate() method.
+	 * in addition to the $this->activate() method.
 	 */
 	public function init() {
 		$installer = new Installer( $this->io, $this->composer );

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -3,10 +3,11 @@
 namespace Altis\Composer;
 
 use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
 
-class Plugin implements PluginInterface {
+class Plugin implements PluginInterface, EventSubscriberInterface {
 
 	/**
 	 * Called when the plugin is activated.
@@ -15,14 +16,30 @@ class Plugin implements PluginInterface {
 	 * @param IOInterface $io
 	 */
 	public function activate( Composer $composer, IOInterface $io ) {
-		$default_installer = $composer->getInstallationManager()->getInstaller( 'library' );
-		$current_installer = $composer->getInstallationManager()->getInstaller( 'wordpress-plugin' );
-		if ( $current_installer && $current_installer !== $default_installer ) {
-			$composer->getInstallationManager()->removeInstaller( $current_installer );
-		}
+		$this->composer = $composer;
+		$this->io = $io;
 
-		$installer = new Installer( $io, $composer );
-		$composer->getInstallationManager()->addInstaller( $installer );
+	}
 
+	/**
+	 * Get the events the plugin subscribed to.
+	 *
+	 * @return array
+	 */
+	public static function getSubscribedEvents() {
+		return [
+			'init' => 'init',
+		];
+	}
+
+	/**
+	 * Register the installer on the `init` hook.
+	 *
+	 * We want to register later than the composer-installers installer
+	 * as the last-added installer takes precedence.
+	 */
+	public function init() {
+		$installer = new Installer( $this->io, $this->composer );
+		$this->composer->getInstallationManager()->addInstaller( $installer );
 	}
 }


### PR DESCRIPTION
Composer installers take precedence by latest-added. Out installer can get
added before the composer-installers installer. That means that it will be
responsible for installing wordpress-plugin packages, which means we don't
get to install them into `vendor` based off our whitelist.

We instead register the installer "late" on `init`, which happens after all
plugins are loaded, but before packages are installed.