### PR TITLE
Add about pages

### DIFF
--- a/inc/about/namespace.php
+++ b/inc/about/namespace.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Altis\About;
+
+use function ALtis\get_composer_data;
+use Altis\Module;
+use WP_Admin_Bar;
+
+const PAGE_SLUG = 'altis-about';
+
+/**
+ * Bootstrap About pages.
+ */
+function bootstrap() {
+	add_action( 'admin_bar_menu', __NAMESPACE__ . '\\register_menu_item', 0 );
+	add_action( 'load-about.php', __NAMESPACE__ . '\\render_about_page', 1000 );
+	add_action( 'load-credits.php', __NAMESPACE__ . '\\render_credits_page', 1000 );
+}
+
+/**
+ * Add the Altis logo menu.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar
+ */
+function register_menu_item( WP_Admin_Bar $wp_admin_bar ) {
+	$logo_menu_args = [
+		'id' => 'altis-about',
+		'parent' => 'altis',
+		'title' => 'About',
+		'href' => admin_url( 'about.php' ),
+	];
+
+	$wp_admin_bar->add_menu( $logo_menu_args );
+}
+
+/**
+ * Get versions for all modules.
+ *
+ * @return array Map of module slug => module data.
+ */
+function get_module_version_data() {
+	$composer_data = get_composer_data();
+	$modules = Module::get_all();
+
+	$data = [];
+	foreach ( $modules as $module ) {
+		/** @var Module $module */
+		$package = sprintf( 'altis/%s', basename( $module->get_directory() ) );
+		$package_data = $composer_data[ $package ] ?? null;
+		$data[ $module->get_slug() ] = (object) [
+			'module' => $module,
+			'version' => (object) [
+				'human' => $package_data ? $package_data->version : 'Unknown',
+				'sha' => $package_data ? $package_data->dist->reference : 'Unknown',
+			],
+		];
+	}
+
+	return $data;
+}
+
+/**
+ * Get the license for a specific package.
+ *
+ * Returns a SPDX identifier for the given package.
+ *
+ * @link https://spdx.org/licenses/
+ *
+ * @param string $package Package name.
+ * @return string|null Package license if known, or null otherwise.
+ */
+function get_package_license( $package ) {
+	// Manually except some packages which have inaccurate Composer
+	// license data.
+	$exceptions = [
+		'humanmade/stream' => 'GPL-2.0-or-later',
+		'humanmade/two-factor' => 'GPL-2.0-or-later',
+		'humanmade/wp-redis-predis-client' => 'GPL-2.0-or-later',
+		'humanmade/wp-redis' => 'GPL-2.0-or-later',
+	];
+	if ( isset( $exceptions[ $package ] ) ) {
+		return $exceptions[ $package ];
+	}
+
+	$all_packages = get_composer_data();
+	$package_data = $all_packages[ $package ] ?? null;
+	if ( empty( $package_data ) || empty( $package_data->license ) ) {
+		return null;
+	}
+	return implode( ',', $package_data->license );
+}
+
+/**
+ * Render the About page.
+ *
+ * This is hooked in early on the about.php page, allowing us to hijack the
+ * page and render our own About page instead.
+ */
+function render_about_page() {
+	$GLOBALS['title'] = __( 'About', 'altis' );
+
+	require ABSPATH . 'wp-admin/admin-header.php';
+
+	?>
+	<div class="wrap about-wrap full-width-layout">
+		<h1><?php esc_html_e( 'Powered by Altis', 'altis' ) ?></h1>
+
+		<p class="about-text"><?php esc_html_e( 'Welcome to Altis, the next-generation digital experience platform.', 'altis' ) ?></p>
+
+		<h2 class="nav-tab-wrapper wp-clearfix">
+			<a href="<?php echo admin_url( 'about.php' ) ?>" class="nav-tab nav-tab-active"><?php esc_html_e( 'About', 'altis' ) ?></a>
+			<a href="<?php echo admin_url( 'credits.php' ) ?>" class="nav-tab"><?php esc_html_e( 'Credits', 'altis' ) ?></a>
+		</h2>
+	</div>
+
+	<h2><?php esc_html_e( 'Current Module Versions', 'altis' ) ?></h2>
+
+	<table class="widefat striped">
+		<?php foreach ( get_module_version_data() as $module_data ) : ?>
+			<tr>
+				<th scope="row"><?php echo esc_html( $module_data->module->get_title() ) ?></th>
+				<td><?php echo esc_html( sprintf( '%s (%s)', $module_data->version->human, $module_data->version->sha ) ) ?></td>
+			</tr>
+		<?php endforeach ?>
+	</table>
+	<?php
+
+	require ABSPATH . 'wp-admin/admin-footer.php';
+
+	// Exit before we attempt to render WordPress' about page.
+	exit;
+}
+
+/**
+ * Render the Credits page.
+ *
+ * This is hooked in early on the credits.php page, allowing us to hijack the
+ * page and render our own Credits page instead.
+ */
+function render_credits_page() {
+	$GLOBALS['title'] = __( 'Credits', 'altis' );
+
+	require ABSPATH . 'wp-admin/admin-header.php';
+	require ABSPATH . 'wp-admin/includes/credits.php';
+
+	?>
+	<div class="wrap about-wrap full-width-layout">
+		<h1><?php esc_html_e( 'Powered by Altis', 'altis' ) ?></h1>
+
+		<p class="about-text"><?php esc_html_e( 'Welcome to Altis, the next-generation digital experience platform.', 'altis' ) ?></p>
+
+		<h2 class="nav-tab-wrapper wp-clearfix">
+			<a href="<?php echo admin_url( 'about.php' ) ?>" class="nav-tab"><?php esc_html_e( 'About', 'altis' ) ?></a>
+			<a href="<?php echo admin_url( 'credits.php' ) ?>" class="nav-tab nav-tab-active"><?php esc_html_e( 'Credits', 'altis' ) ?></a>
+		</h2>
+
+		<p class="about-description">
+			Altis is created by <a href="https://humanmade.com/">Human Made</a>, and is available under the terms of the GPL v3 licence.
+			Altis is based on <a href="https://wordpress.org/">WordPress</a>, and contains code from many open source projects.
+		</p>
+	</div>
+
+	<div class="wrap full-width-layout">
+		<?php
+		// Generate documentation for Composer dependencies.
+		$packages = get_composer_data();
+		?>
+		<h2><?php esc_html_e( 'Packages', 'altis' ) ?></h2>
+		<p>Altis includes code from the following projects, used under their respective licenses.</p>
+		<table class="widefat striped">
+			<?php foreach ( $packages as $package ) : ?>
+				<tr>
+					<th scope="row">
+						<?php
+						printf(
+							'<a href="%s">%s</a> (%s)',
+							esc_url( 'https://packagist.org/packages/' . $package->name ),
+							esc_html( $package->name ),
+							esc_html( $package->version )
+						);
+						?>
+					</th>
+					<td>
+						<?php
+						printf(
+							'<a href="%s">%s</a>',
+							esc_url( $package->homepage ?? 'https://packagist.org/packages/' . $package->name ),
+							esc_html( get_package_license( $package->name ) )
+						);
+						?>
+					</td>
+				</tr>
+			<?php endforeach ?>
+		</table>
+
+		<?php
+		// Generate documentation for external libraries.
+		$credits = wp_credits();
+		$libraries = $credits['groups']['libraries'] ?? null;
+		if ( ! empty( $libraries ) ) :
+		?>
+
+		<h2><?php esc_html_e( 'Other Libraries', 'altis' ) ?></h2>
+		<p>Altis includes other libraries as part of WordPress.</p>
+		<?php
+		array_walk( $libraries['data'], '_wp_credits_build_object_link' );
+		echo '<p class="wp-credits-list">' . wp_sprintf( '%l.', $libraries['data'] ) . "</p>\n\n";
+		?>
+
+		<?php endif ?>
+
+	</div>
+
+	<?php
+
+	require ABSPATH . 'wp-admin/admin-footer.php';
+
+	// Exit before we attempt to render WordPress' credits page.
+	exit;
+}

--- a/inc/about/namespace.php
+++ b/inc/about/namespace.php
@@ -2,8 +2,8 @@
 
 namespace Altis\About;
 
-use function ALtis\get_composer_data;
 use Altis\Module;
+use function Altis\get_composer_data;
 use WP_Admin_Bar;
 
 const PAGE_SLUG = 'altis-about';

--- a/inc/about/namespace.php
+++ b/inc/about/namespace.php
@@ -38,7 +38,7 @@ function register_menu_item( WP_Admin_Bar $wp_admin_bar ) {
  *
  * @return array Map of module slug => module data.
  */
-function get_module_version_data() {
+function get_module_version_data() : array {
 	$composer_data = get_composer_data();
 	$modules = Module::get_all();
 
@@ -69,7 +69,7 @@ function get_module_version_data() {
  * @param string $package Package name.
  * @return string|null Package license if known, or null otherwise.
  */
-function get_package_license( $package ) {
+function get_package_license( string $package ) {
 	// Manually except some packages which have inaccurate Composer
 	// license data.
 	$exceptions = [

--- a/inc/about/namespace.php
+++ b/inc/about/namespace.php
@@ -198,14 +198,14 @@ function render_credits_page() {
 		$credits = wp_credits();
 		$libraries = $credits['groups']['libraries'] ?? null;
 		if ( ! empty( $libraries ) ) :
-		?>
+			?>
 
-		<h2><?php esc_html_e( 'Other Libraries', 'altis' ) ?></h2>
-		<p>Altis includes other libraries as part of WordPress.</p>
-		<?php
-		array_walk( $libraries['data'], '_wp_credits_build_object_link' );
-		echo '<p class="wp-credits-list">' . wp_sprintf( '%l.', $libraries['data'] ) . "</p>\n\n";
-		?>
+			<h2><?php esc_html_e( 'Other Libraries', 'altis' ) ?></h2>
+			<p>Altis includes other libraries as part of WordPress.</p>
+			<?php
+			array_walk( $libraries['data'], '_wp_credits_build_object_link' );
+			echo '<p class="wp-credits-list">' . wp_sprintf( '%l.', $libraries['data'] ) . "</p>\n\n";
+			?>
 
 		<?php endif ?>
 

--- a/inc/about/namespace.php
+++ b/inc/about/namespace.php
@@ -69,7 +69,7 @@ function get_module_version_data() : array {
  * @param string $package Package name.
  * @return string|null Package license if known, or null otherwise.
  */
-function get_package_license( string $package ) {
+function get_package_license( string $package ) : ?string {
 	// Manually except some packages which have inaccurate Composer
 	// license data.
 	$exceptions = [

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -261,7 +261,7 @@ function load_enabled_modules() {
  *
  * @return array Map of package name => package data.
  */
-function get_composer_data() {
+function get_composer_data() : array {
 	static $data = null;
 
 	if ( empty( $data ) ) {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -10,6 +10,13 @@ namespace Altis;
 use Aws\Sdk;
 
 /**
+ * Bootstrap any core functions as necessary.
+ */
+function bootstrap() {
+	About\bootstrap();
+}
+
+/**
  * Retrieve the configuration for Altis.
  *
  * The configuration is defined by merging the defaults set by modules

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -244,3 +244,29 @@ function load_enabled_modules() {
 	 */
 	do_action( 'altis.modules.loaded' );
 }
+
+/**
+ * Get raw data from Composer's installed.json
+ *
+ * This returns the raw data that Composer generates. installed.json is
+ * equivalent to composer.lock, but is stored within the vendor directory, and
+ * is a more accurate data store.
+ *
+ * @return array Map of package name => package data.
+ */
+function get_composer_data() {
+	static $data = null;
+
+	if ( empty( $data ) ) {
+		$composer_file = ROOT_DIR . '/vendor/composer/installed.json';
+		$raw_data = json_decode( file_get_contents( $composer_file ) );
+
+		// Re-index by package slug.
+		$data = [];
+		foreach ( $raw_data as $package ) {
+			$data[ $package->name ] = $package;
+		}
+	}
+
+	return $data;
+}

--- a/load.php
+++ b/load.php
@@ -7,6 +7,7 @@ namespace Altis;
 
 // Get module functions.
 require_once __DIR__ . '/inc/namespace.php';
+require_once __DIR__ . '/inc/about/namespace.php';
 
 // Don't self-initialize if this is not an Altis execution.
 if ( ! function_exists( 'add_action' ) ) {
@@ -29,9 +30,15 @@ add_action( 'altis.loaded_autoloader', function () {
 
 // Register core module.
 add_action( 'altis.modules.init', function () {
-	register_module( 'core', __DIR__, 'Core', [
-		'enabled' => true,
-	] );
+	register_module(
+		'core',
+		__DIR__,
+		'Core',
+		[
+			'enabled' => true,
+		],
+		__NAMESPACE__ . '\\bootstrap'
+	);
 } );
 
 // Load config entry point.


### PR DESCRIPTION
Fixes #32. Needs a lot more stuff done first though. We should also get design and marketing passes here, as right now all I've done is spit out all the raw data.

## About Page

![Screenshot_2019-05-23 About ‹ WordPress Site — Altis](https://user-images.githubusercontent.com/21655/58259532-aa620000-7d6c-11e9-9ebb-4282072179e2.png)

## Credits Page

![Screenshot_2019-05-23 Credits ‹ WordPress Site — Altis(1)](https://user-images.githubusercontent.com/21655/58259541-ae8e1d80-7d6c-11e9-9457-806bcccc71c5.png)
