### PR TITLE
Upgrade AWS SDK 3.73.0 -> 3.101.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=7.1",
-		"aws/aws-sdk-php": "^3.73.0",
+		"aws/aws-sdk-php": "^3.101.1",
 		"composer-plugin-api": "^1.0",
 		"composer/installers": "^1.4"
 	},


### PR DESCRIPTION
Support for ECS Deployments using CodeDeploy was added in 3.77.0. I had the mind to update to just that, but as it's been a while since we updated, I figured an update-to-latest would be good to pick up on other changes. I'll update over there as well!