### PR TITLE
Allow AWS SDK to be configured via altis configuration json.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,30 @@ The AWS SDK is always available and preconfigured with the necessary credentials
 
 Returns an instance of the base AWS SDK with preconfigured credentials.
 
-The credentials can be supplied locally by defining the constants `HM_ENV_REGION`, `AWS_KEY` and `AWS_SECRET`.
+The credentials can be supplied by providing the `modules.core.aws` setting in the configuration. It's recommended that this be done only for the local environment:
+
+
+```
+{
+	"extra": {
+		"altis": {
+			"environments":{
+				"local": {
+					"modules": {
+						"core" : {
+							"aws":{
+								"region": "us-east-1",
+								"key": "xxxxxxxxxxxxxxxxxxxx",
+								"secret: "xxxxxxxxxxxxxxxxxxxxxxxxxx"
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+```
 
 ## Autoloader
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -127,9 +127,17 @@ function get_aws_sdk() : Sdk {
 		return $sdk;
 	}
 	$params = [
-		'region'   => HM_ENV_REGION,
 		'version'  => 'latest',
 	];
+
+	$config = get_config();
+	if ( isset( $config['core']['aws'] ) ) {
+		$params = array_merge( $params, $config['core']['aws'] );
+	}
+
+	if ( defined( 'HM_ENV_REGION' ) ) {
+		$params['region'] = HM_ENV_REGION;
+	}
 	if ( defined( 'AWS_KEY' ) ) {
 		$params['credentials'] = [
 			'key'    => AWS_KEY,


### PR DESCRIPTION
Rather than relying on the constants to be defined, we should move the AWS config to the core module's configuration.

Fixes https://github.com/humanmade/altis-core/issues/31.