### PR TITLE
Add safe-svg plugin to composer wp plugin exclude list

### DIFF
--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -27,6 +27,7 @@ class Installer extends BaseInstaller {
 			'10up/elasticpress',
 			'altis/aws-analytics',
 			'altis/experiments',
+			'darylldoyle/safe-svg',
 			'humanmade/amp',
 			'humanmade/aws-rekognition',
 			'humanmade/cavalcade',


### PR DESCRIPTION
For humanmade/altis-cms#63

Corresponds to humanmade/altis-media#35.