### PR TITLE
Ensure core module is bootstrapped first

### DIFF
--- a/load.php
+++ b/load.php
@@ -30,7 +30,7 @@ add_action( 'altis.modules.init', function () {
 		],
 		__NAMESPACE__ . '\\bootstrap'
 	);
-} );
+}, 1 );
 
 // Load config entry point.
 add_action( 'altis.loaded_autoloader', function () {


### PR DESCRIPTION
The set up done here is important for other modules to make use of.