### PR TITLE
add php-basic-auth to list of excluded plugins

### DIFF
--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -41,6 +41,7 @@ class Installer extends BaseInstaller {
 			'humanmade/hm-limit-login-attempts',
 			'humanmade/meta-tags',
 			'humanmade/msm-sitemap',
+			'humanmade/php-basic-auth',
 			'humanmade/publication-checklist',
 			'humanmade/require-login',
 			'humanmade/s3-uploads',


### PR DESCRIPTION
allow it to be installed to the vendor directory rather than content/mu-plugins

required for https://github.com/humanmade/altis-security/issues/45