### PR TITLE
Add HM debug bar for Elastic Press to exclude plugins list

### DIFF
--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -24,7 +24,6 @@ class Installer extends BaseInstaller {
 		 * not installed to the wp-content/plugins path.
 		 */
 		$excluded_plugins = [
-			'10up/debug-bar-elasticpress',
 			'10up/elasticpress',
 			'altis/aws-analytics',
 			'altis/browser-security',
@@ -34,6 +33,7 @@ class Installer extends BaseInstaller {
 			'humanmade/aws-rekognition',
 			'humanmade/aws-ses-wp-mail',
 			'humanmade/cavalcade',
+			'humanmade/debug-bar-elasticpress',
 			'humanmade/delegated-oauth',
 			'humanmade/facebook-instant-articles-wp',
 			'humanmade/gaussholder',


### PR DESCRIPTION
Part of https://github.com/humanmade/altis-enhanced-search/issues/55

We switched to our fork as we fixed up some issues from original plugin.
