### PR TITLE
Add post cloner plugin to allowlist

### DIFF
--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -59,6 +59,7 @@ class Installer extends BaseInstaller {
 			'humanmade/msm-sitemap',
 			'humanmade/php-basic-auth',
 			'humanmade/publication-checklist',
+			'humanmade/post-cloner',
 			'humanmade/require-login',
 			'humanmade/s3-uploads',
 			'humanmade/smart-media',


### PR DESCRIPTION
This will allow for https://github.com/humanmade/altis-cms/pull/248 - including the post cloner plugin to the CMS module

Doh, old habits die hard, forgot to use "allowlist" in the commit message