### PR TITLE
Define WP_ENVIRONMENT_TYPE

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -218,9 +218,6 @@ function get_environment_type() : string {
 	if ( defined( 'HM_ENV_TYPE' ) ) {
 		return HM_ENV_TYPE;
 	}
-	if ( defined( 'WP_ENVIRONMENT_TYPE' ) ) {
-		return WP_ENVIRONMENT_TYPE;
-	}
 	return 'local';
 }
 
@@ -288,11 +285,7 @@ function set_wp_environment_type() : void {
 	if ( defined( 'WP_ENVIRONMENT_TYPE' ) ) {
 		return;
 	}
-	if ( defined( 'HM_ENV_TYPE' ) ) {
-		define( 'WP_ENVIRONMENT_TYPE', HM_ENV_TYPE );
-	} else {
-		define( 'WP_ENVIRONMENT_TYPE', 'local' );
-	}
+	define( 'WP_ENVIRONMENT_TYPE', get_environment_type() );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -280,6 +280,22 @@ function fix_plugins_url( string $url, string $path, string $plugin ) : string {
 }
 
 /**
+ * Sets the WP_ENVIRONMENT_TYPE constant.
+ *
+ * @return void
+ */
+function set_wp_environment_type() : void {
+	if ( defined( 'WP_ENVIRONMENT_TYPE' ) ) {
+		return;
+	}
+	if ( defined( 'HM_ENV_TYPE' ) ) {
+		define( 'WP_ENVIRONMENT_TYPE', HM_ENV_TYPE );
+	} else {
+		define( 'WP_ENVIRONMENT_TYPE', 'local' );
+	}
+}
+
+/**
  * Registers a module with the store.
  *
  * @param string $slug The string identifier for the module used for later reference.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -218,6 +218,9 @@ function get_environment_type() : string {
 	if ( defined( 'HM_ENV_TYPE' ) ) {
 		return HM_ENV_TYPE;
 	}
+	if ( defined( 'WP_ENVIRONMENT_TYPE' ) ) {
+		return WP_ENVIRONMENT_TYPE;
+	}
 	return 'local';
 }
 

--- a/load.php
+++ b/load.php
@@ -10,6 +10,18 @@ namespace Altis;
 // Patch plugins URL for vendor directory.
 add_filter( 'plugins_url', 'Altis\\fix_plugins_url', 10, 3 );
 
+// Ensure WP_ENVIRONMENT_TYPE is set.
+add_action( 'altis.loaded_autoloader', function () {
+	if ( defined( 'WP_ENVIRONMENT_TYPE' ) ) {
+		return;
+	}
+	if ( defined( 'HM_ENV_TYPE' ) ) {
+		define( 'WP_ENVIRONMENT_TYPE', HM_ENV_TYPE );
+	} else {
+		define( 'WP_ENVIRONMENT_TYPE', 'local' );
+	}
+}, -10 );
+
 // Fire module init hook and load enabled modules.
 add_action( 'altis.loaded_autoloader', function () {
 	/**

--- a/load.php
+++ b/load.php
@@ -11,16 +11,7 @@ namespace Altis;
 add_filter( 'plugins_url', 'Altis\\fix_plugins_url', 10, 3 );
 
 // Ensure WP_ENVIRONMENT_TYPE is set.
-add_action( 'altis.loaded_autoloader', function () {
-	if ( defined( 'WP_ENVIRONMENT_TYPE' ) ) {
-		return;
-	}
-	if ( defined( 'HM_ENV_TYPE' ) ) {
-		define( 'WP_ENVIRONMENT_TYPE', HM_ENV_TYPE );
-	} else {
-		define( 'WP_ENVIRONMENT_TYPE', 'local' );
-	}
-}, -10 );
+add_action( 'altis.loaded_autoloader', 'Altis\\set_wp_environment_type', -10 );
 
 // Fire module init hook and load enabled modules.
 add_action( 'altis.loaded_autoloader', function () {


### PR DESCRIPTION
As part of the WP 5.5 compatibility work this mirrors the `HM_ENV_TYPE` constant to the new core `WP_ENVIRONMENT_TYPE` constant which defaults to "local". This will seemlessly work with the cloud module `wp-config.php` and `wp-config-produciton.php` files should we add `WP_ENVIRONMENT_TYPE` as an environment variable to our infrastructure in future.

See https://github.com/humanmade/altis-cms/issues/239