### PR TITLE
update the composer file to add in the consent js api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
 	"require": {
 		"php": ">=7.1",
 		"altis/consent": "~1.0.0",
+		"altis/consent-api": "~1.0.2",
 		"aws/aws-sdk-php": "^3.150.0",
 		"composer-plugin-api": "^1.1 || ^2.0",
 		"composer/installers": "^1.4"


### PR DESCRIPTION
Adds `altis/consent-api` to the composer file so it's not a nested dependency.