### PR TITLE
Fix About page for Composer v2

### DIFF
--- a/inc/about/namespace.php
+++ b/inc/about/namespace.php
@@ -49,7 +49,11 @@ function get_module_version_data() : array {
 
 	$data = [];
 	foreach ( $modules as $module ) {
-		/** @var Module $module Altis module object. */
+		/**
+		 * Altis module object.
+		 *
+		 * @var Module $module
+		 */
 		$package = sprintf( 'altis/%s', basename( $module->get_directory() ) );
 		$package_data = $composer_data[ $package ] ?? null;
 		$data[ $module->get_slug() ] = (object) [

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -57,12 +57,18 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @param Composer $composer The composer class.
+	 * @param IOInterface $io The composer disk interface.
 	 */
 	public function deactivate( Composer $composer, IOInterface $io ) {
 	}
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @param Composer $composer The composer class.
+	 * @param IOInterface $io The composer disk interface.
 	 */
 	public function uninstall( Composer $composer, IOInterface $io ) {
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -428,6 +428,11 @@ function get_composer_data() : array {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$raw_data = json_decode( file_get_contents( $composer_file ) );
 
+		// Composer v2 file version support.
+		if ( isset( $raw_data->packages ) ) {
+			$raw_data = $raw_data->packages;
+		}
+
 		// Re-index by package slug.
 		$data = [];
 		foreach ( $raw_data as $package ) {


### PR DESCRIPTION
The About page code looks at the `installed.json` file created by Composer after installing or updating. As of Composer v2 this appears to have some new top level items and is no longer just an array of packages.

This fixes #113