### PR TITLE
Add consent API plugins to safelist

### DIFF
--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -42,6 +42,8 @@ class Installer extends BaseInstaller {
 			'10up/elasticpress',
 			'altis/aws-analytics',
 			'altis/browser-security',
+			'altis/consent',
+			'altis/consent-api',
 			'altis/experiments',
 			'darylldoyle/safe-svg',
 			'humanmade/aws-rekognition',


### PR DESCRIPTION
These were removed by the consent API revert.