### PR TITLE
Pull overridden paths dynamically from packages

### DIFF
--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -39,7 +39,7 @@ class Installer extends BaseInstaller {
 	/**
 	 * Gets all overridden packages from all extra.altis.install-overrides entries
 	 *
-	 * @param string[] $overrides
+	 * @param string[] $overrides Overridden package names.
 	 */
 	public function setInstallOverrides( $overrides ) : void {
 		$this->installOverrides = $overrides;

--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -10,6 +10,9 @@ namespace Altis\Composer;
 use Composer\Installers\Installer as BaseInstaller;
 use Composer\Package\PackageInterface;
 
+// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Snake case to match Composer.
+// phpcs:disable WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Snake case to match Composer.
+
 /**
  * Altis Core Composer Installer.
  */

--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -14,6 +14,7 @@ use Composer\Package\PackageInterface;
  * Altis Core Composer Installer.
  */
 class Installer extends BaseInstaller {
+	protected $installOverrides = [];
 
 	/**
 	 * Check if the installer supports a given type.
@@ -28,24 +29,10 @@ class Installer extends BaseInstaller {
 	/**
 	 * Gets all overridden packages from all extra.altis.install-overrides entries
 	 *
-	 * @return string[]
+	 * @param string[] $overrides
 	 */
-	protected function getAllInstallOverrides() {
-		$rm = $this->composer->getRepositoryManager();
-		$repo = $rm->getLocalRepository();
-		$packages = $repo->getPackages();
-
-		$overridden = [];
-		foreach ( $packages as $package ) {
-			$extra = $package->getExtra();
-			if ( ! isset( $extra['altis'] ) || ! isset( $extra['altis']['install-overrides'] ) ) {
-				continue;
-			}
-
-			$overridden = array_merge( $overridden, $extra['altis']['install-overrides'] );
-		}
-
-		return $overridden;
+	public function setInstallOverrides( $overrides ) : void {
+		$this->installOverrides = $overrides;
 	}
 
 	/**
@@ -98,8 +85,7 @@ class Installer extends BaseInstaller {
 			'stuttter/wp-user-signups',
 		];
 
-		$overrides = $this->getAllInstallOverrides();
-		$excluded_plugins = array_unique( array_merge( $legacy, $overrides ) );
+		$excluded_plugins = array_unique( array_merge( $legacy, $this->installOverrides ) );
 
 		if ( ! in_array( $package->getType(), [ 'wordpress-plugin', 'wordpress-muplugin' ], true ) || ! in_array( $package->getName(), $excluded_plugins, true ) ) {
 			return parent::getInstallPath( $package, $framework_type );

--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -10,12 +10,17 @@ namespace Altis\Composer;
 use Composer\Installers\Installer as BaseInstaller;
 use Composer\Package\PackageInterface;
 
-// @codingStandardsIgnoreStart WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Snake case to match Composer.
-
 /**
  * Altis Core Composer Installer.
  */
 class Installer extends BaseInstaller {
+	/**
+	 * Overridden packages.
+	 *
+	 * Set in setInstallOverrides by the plugin hooks.
+	 *
+	 * @var string[]
+	 */
 	protected $installOverrides = [];
 
 	/**

--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -4,12 +4,13 @@
  *
  * @package altis/core
  */
-// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Snake case to match Composer.
 
 namespace Altis\Composer;
 
 use Composer\Installers\Installer as BaseInstaller;
 use Composer\Package\PackageInterface;
+
+// @codingStandardsIgnoreStart WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Snake case to match Composer.
 
 /**
  * Altis Core Composer Installer.

--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Snake case to match Composer.
 /**
  * Altis Core Installer.
  *

--- a/inc/composer/class-installer.php
+++ b/inc/composer/class-installer.php
@@ -1,10 +1,10 @@
 <?php
-// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Snake case to match Composer.
 /**
  * Altis Core Installer.
  *
  * @package altis/core
  */
+// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Snake case to match Composer.
 
 namespace Altis\Composer;
 

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -20,6 +20,11 @@ use Composer\Plugin\PluginInterface;
  * Altis core composer plugin.
  */
 class Plugin implements PluginInterface, EventSubscriberInterface {
+	/**
+	 * Custom installer instance.
+	 *
+	 * @var Installer
+	 */
 	protected $installer;
 
 	/**
@@ -67,7 +72,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	/**
 	 * Update install overrides once dependencies have been resolved. (Composer v2)
 	 *
-	 * @param InstallerEvent $event
+	 * @param InstallerEvent $event Pre-operations installer event.
 	 * @return void
 	 */
 	public function pre_operations_exec( InstallerEvent $event ) : void {
@@ -128,7 +133,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	/**
 	 * Update install overrides once dependencies have been resolved. (Composer v1)
 	 *
-	 * @param InstallerEvent $event
+	 * @param InstallerEvent $event Post-solving event.
 	 * @return void
 	 */
 	public function post_dependencies_solving( InstallerEvent $event ) : void {

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -14,8 +14,6 @@ use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Installer\InstallerEvent;
 use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
-use Composer\DependencyResolver\Operation\OperationInterface;
-use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginInterface;
 
 /**
@@ -94,7 +92,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	 * Resolve packages after operations for Composer v2
 	 *
 	 * @param array $packages Map of package name => package instance for already installed packages.
-	 * @param OperationInterface[] $operations List of operations
+	 * @param \Composer\DependencyResolver\Operation\OperationInterface[] $operations List of operations
 	 * @return string[] List of packages to override.
 	 */
 	protected function resolve_packages_composer_v2( array $packages, array $operations ) {
@@ -221,7 +219,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	/**
 	 * Gets all overridden packages from all extra.altis.install-overrides entries
 	 *
-	 * @param PackageInterface[] $packages
+	 * @param \Composer\Package\PackageInterface[] $packages
 	 * @return string[]
 	 */
 	protected function getAllInstallOverrides( $packages ) {

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -127,7 +127,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 			}
 		}
 
-		return $this->getAllInstallOverrides( $packages );
+		return $this->get_all_install_overrides( $packages );
 	}
 
 	/**
@@ -174,7 +174,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 			}
 		}
 
-		$overrides = $this->getAllInstallOverrides( $packages );
+		$overrides = $this->get_all_install_overrides( $packages );
 		$this->installer->setInstallOverrides( $overrides );
 	}
 
@@ -182,8 +182,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	 * Handle first install of the altis/core package.
 	 *
 	 * @param PackageEvent Package installation event.
+	 * @return void
 	 */
-	public function post_package_install( PackageEvent $event ) {
+	public function post_package_install( PackageEvent $event ) : void {
 		// See if we just got installed.
 		$operation = $event->getOperation();
 		if ( ! $operation instanceof InstallOperation && ! $operation instanceof UpdateOperation ) {
@@ -227,7 +228,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	 * @param \Composer\Package\PackageInterface[] $packages
 	 * @return string[]
 	 */
-	protected function getAllInstallOverrides( $packages ) {
+	protected function get_all_install_overrides( $packages ) : array {
 		$overridden = [];
 		foreach ( $packages as $package ) {
 			$extra = $package->getExtra();

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -181,7 +181,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	/**
 	 * Handle first install of the altis/core package.
 	 *
-	 * @param PackageEvent Package installation event.
+	 * @param PackageEvent $event Package installation event.
 	 * @return void
 	 */
 	public function post_package_install( PackageEvent $event ) : void {
@@ -201,7 +201,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		// so we need to do so now. PackageEvent subclasses InstallerEvent
 		// in Composer v1, but not in v2.
 		if ( $event instanceof InstallerEvent ) {
-			// Composer v1
+			// Composer v1.
 			$this->post_dependencies_solving( $event );
 			return;
 		}
@@ -225,7 +225,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	/**
 	 * Gets all overridden packages from all extra.altis.install-overrides entries
 	 *
-	 * @param \Composer\Package\PackageInterface[] $packages
+	 * @param \Composer\Package\PackageInterface[] $packages All packages being installed.
 	 * @return string[]
 	 */
 	protected function get_all_install_overrides( $packages ) : array {

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -70,7 +70,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	 * @param InstallerEvent $event
 	 * @return void
 	 */
-	public function pre_operations_exec( InstallerEvent $event )  {
+	public function pre_operations_exec( InstallerEvent $event ) : void {
 		$transaction = $event->getTransaction();
 		$operations = $transaction->getOperations();
 		if ( empty( $operations ) ) {
@@ -84,6 +84,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 			$packages[ $package->getName() ] = $package;
 		}
 
+		// Then, resolve the operations we're about to apply.
+		// In Composer v2, this is when running the initial install step.
 		$overrides = $this->resolve_packages_composer_v2( $packages, $operations );
 		$this->installer->setInstallOverrides( $overrides );
 	}
@@ -95,9 +97,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	 * @param \Composer\DependencyResolver\Operation\OperationInterface[] $operations List of operations
 	 * @return string[] List of packages to override.
 	 */
-	protected function resolve_packages_composer_v2( array $packages, array $operations ) {
-		// Then, resolve the operations we're about to apply.
-		// (In Composer v2, this is when running the initial install step.)
+	protected function resolve_packages_composer_v2( array $packages, array $operations ) : array {
 		foreach ( $operations as $operation ) {
 			switch ( $operation::TYPE ) {
 				case 'install':
@@ -131,7 +131,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	 * @param InstallerEvent $event
 	 * @return void
 	 */
-	public function post_dependencies_solving( InstallerEvent $event )  {
+	public function post_dependencies_solving( InstallerEvent $event ) : void {
 		$operations = $event->getOperations();
 		if ( empty( $operations ) ) {
 			return;

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -9,13 +9,16 @@ namespace Altis\Composer;
 
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\Installer\InstallerEvent;
 use Composer\IO\IOInterface;
+use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginInterface;
 
 /**
  * Altis core composer plugin.
  */
 class Plugin implements PluginInterface, EventSubscriberInterface {
+	protected $installer;
 
 	/**
 	 * Called when the plugin is activated.
@@ -27,8 +30,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		$this->composer = $composer;
 		$this->io = $io;
 
-		$installer = new Installer( $this->io, $this->composer );
-		$this->composer->getInstallationManager()->addInstaller( $installer );
+		$this->installer = new Installer( $this->io, $this->composer );
+		$this->composer->getInstallationManager()->addInstaller( $this->installer );
 	}
 
 	/**
@@ -39,6 +42,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	public static function getSubscribedEvents() {
 		return [
 			'init' => 'init',
+			'post-dependencies-solving' => 'post_dependencies_solving',
 		];
 	}
 
@@ -51,8 +55,76 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	 * in addition to the $this->activate() method.
 	 */
 	public function init() {
-		$installer = new Installer( $this->io, $this->composer );
-		$this->composer->getInstallationManager()->addInstaller( $installer );
+		$this->installer = new Installer( $this->io, $this->composer );
+		$this->composer->getInstallationManager()->addInstaller( $this->installer );
+	}
+
+	/**
+	 * Update install overrides once dependencies have been resolved.
+	 *
+	 * @param InstallerEvent $event
+	 * @return void
+	 */
+	public function post_dependencies_solving( InstallerEvent $event )  {
+		$operations = $event->getOperations();
+		if ( empty( $operations ) ) {
+			return;
+		}
+
+		// First, work out which packages we already have.
+		$repo = $event->getInstalledRepo();
+		$packages = [];
+		foreach ( $repo->getPackages() as $package ) {
+			$packages[ $package->getName() ] = $package;
+		}
+
+		// Then, resolve the operations we're about to apply.
+		foreach ( $operations as $operation ) {
+			switch ( $operation->getJobType() ) {
+				case 'install':
+				case 'markAliasInstalled':
+					$package = $operation->getPackage();
+					$packages[ $package->getName() ] = $package;
+					break;
+
+				case 'update':
+					$package = $operation->getTargetPackage();
+					$packages[ $package->getName() ] = $package;
+					break;
+
+				case 'uninstall':
+				case 'markAliasUninstalled':
+					$package = $operation->getPackage();
+					unset( $packages[ $package->getName() ] );
+					break;
+
+				default:
+					break;
+			}
+		}
+
+		$overrides = $this->getAllInstallOverrides( $packages );
+		$this->installer->setInstallOverrides( $overrides );
+	}
+
+	/**
+	 * Gets all overridden packages from all extra.altis.install-overrides entries
+	 *
+	 * @param PackageInterface[] $packages
+	 * @return string[]
+	 */
+	protected function getAllInstallOverrides( $packages ) {
+		$overridden = [];
+		foreach ( $packages as $package ) {
+			$extra = $package->getExtra();
+			if ( ! isset( $extra['altis'] ) || ! isset( $extra['altis']['install-overrides'] ) ) {
+				continue;
+			}
+
+			$overridden = array_merge( $overridden, $extra['altis']['install-overrides'] );
+		}
+
+		return $overridden;
 	}
 
 	/**

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -9,6 +9,7 @@ namespace Altis\Composer;
 
 use Composer\Composer;
 use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\DependencyResolver\Operation\UpdateOperation;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Installer\InstallerEvent;
 use Composer\Installer\PackageEvent;
@@ -48,6 +49,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 			'pre-operations-exec' => 'pre_operations_exec',
 			'post-dependencies-solving' => 'post_dependencies_solving',
 			'post-package-install' => 'post_package_install',
+			'post-package-update' => 'post_package_install',
 		];
 	}
 
@@ -181,7 +183,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	public function post_package_install( PackageEvent $event ) {
 		// See if we just got installed.
 		$operation = $event->getOperation();
-		if ( ! $operation instanceof InstallOperation || $operation->getPackage()->getName() !== 'altis/core' ) {
+		if ( ! $operation instanceof InstallOperation && ! $operation instanceof UpdateOperation ) {
+			return;
+		}
+
+		$package = $operation instanceof UpdateOperation ? $operation->getTargetPackage() : $operation->getPackage();
+		if ( $package->getName() !== 'altis/core' ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #119.

Rather than hardcoding the list in altis/core, it pulls from a `extra.altis.install-overrides` entry in each package's `composer.json`. These entries are from the *new* version, rather than the old one, meaning that package entries are always up-to-date.

I've left the legacy list of packages in here until such time as we update every module. We should do this for v6 ideally, then remove the legacy entries in v7 after validating this works.

I've checked this locally briefly, and `$package` is definitely the new copy; additionally, the `extra.altis` entries are there. That said, I want to do more robust testing before we ship anything here.