### PR TITLE
Rename installer class to prevent using the old instance

### DIFF
--- a/inc/composer/class-installer-v6.php
+++ b/inc/composer/class-installer-v6.php
@@ -16,7 +16,7 @@ use Composer\Package\PackageInterface;
 /**
  * Altis Core Composer Installer.
  */
-class Installer extends BaseInstaller {
+class Installer_V6 extends BaseInstaller {
 	/**
 	 * Overridden packages.
 	 *

--- a/inc/composer/class-override-installer.php
+++ b/inc/composer/class-override-installer.php
@@ -16,7 +16,7 @@ use Composer\Package\PackageInterface;
 /**
  * Altis Core Composer Installer.
  */
-class Installer_V6 extends BaseInstaller {
+class Override_Installer extends BaseInstaller {
 	/**
 	 * Overridden packages.
 	 *

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -37,7 +37,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		$this->composer = $composer;
 		$this->io = $io;
 
-		$this->installer = new Installer( $this->io, $this->composer );
+		$this->installer = new Installer_V6( $this->io, $this->composer );
 		$this->composer->getInstallationManager()->addInstaller( $this->installer );
 	}
 
@@ -65,7 +65,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	 * in addition to the $this->activate() method.
 	 */
 	public function init() {
-		$this->installer = new Installer( $this->io, $this->composer );
+		$this->installer = new Installer_V6( $this->io, $this->composer );
 		$this->composer->getInstallationManager()->addInstaller( $this->installer );
 	}
 

--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -37,7 +37,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 		$this->composer = $composer;
 		$this->io = $io;
 
-		$this->installer = new Installer_V6( $this->io, $this->composer );
+		$this->installer = new Override_Installer( $this->io, $this->composer );
 		$this->composer->getInstallationManager()->addInstaller( $this->installer );
 	}
 
@@ -65,7 +65,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 	 * in addition to the $this->activate() method.
 	 */
 	public function init() {
-		$this->installer = new Installer_V6( $this->io, $this->composer );
+		$this->installer = new Override_Installer( $this->io, $this->composer );
 		$this->composer->getInstallationManager()->addInstaller( $this->installer );
 	}
 


### PR DESCRIPTION
Due to the way composer plugins are evaluated during install we need to ensure the new installer is used and not still in memory by updating the class name. After this change everything works as expected and all plugins are in the correct location.