### PR TITLE
Add Global Content Repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
 	"autoload": {
 		"files": [
 			"inc/namespace.php",
-			"inc/about/namespace.php"
+			"inc/about/namespace.php",
+			"inc/global_content/namespace.php"
 		],
 		"classmap": [
 			"inc/"

--- a/docs/cli-command.md
+++ b/docs/cli-command.md
@@ -1,0 +1,34 @@
+# Altis CLI Command
+
+The Altis CLI command is used for general maintenance tasks and allows other modules and custom code to hook in.
+
+## `wp altis migrate`
+
+The migration command runs all basic maintenance tasks required after upgrading Altis. By default this includes:
+
+- Ensuring the WordPress database schema is up to date
+- Ensuring the Cavalcade database schema is up to date
+- Creating the [Global Content Repository](./global-content-repository.md)
+
+There are 2 ways to hook into this command:
+
+1. Using the `altis.migrate` action hook:
+   ```php
+   add_action( 'altis.migrate', function ( array $args, array $assoc_args ) {
+       // Run upgrade routines here.
+   } );
+   ```
+2. Using WP CLI hooks:
+   ```php
+   WP_CLI::add_hook( 'after_invoke:altis migrate', function () {
+       // Run migration routines here.
+   } );
+   ```
+
+If you wish to run additional WP CLI commands on this hook you can do so using the `WP_CLI::runcommand()` method.
+
+```php
+WP_CLI::add_hook( 'after_invoke:altis migrate', function () {
+    WP_CLI::runcommand( 'cli info' );
+} );
+```

--- a/docs/global-content-repository.md
+++ b/docs/global-content-repository.md
@@ -8,9 +8,9 @@ By default the Global Content Repository only exposes the user management admin.
 
 Users on the multisite network can have different roles on different sites. This gives you control over who can add and edit global content versus who can only use the global content on their own site.
 
-You might have a user who is an author on the main site, but only a subscriber to the Global Content Repository meaning they could read content to use in their posts but not create or edit global content.
+You might have a user who is an author on the main site, but have no role on the Global Content Repository meaning they could read content to use in their posts but not create or edit global content nor access the global site admin.
 
-Conversely you may have a user who does not have access to your primary site but who can create and edit content on the Global Content Repository.
+Conversely you may have a user who does not have a role on your primary site but who can create and edit content on the Global Content Repository site.
 
 ## Functions
 
@@ -35,6 +35,20 @@ Returns the list of page slugs allowe din the Global Content Repository site adm
 **`altis.core.global_content_site_args : array $args`**
 
 Filters the arguments used to create the Global Content Repository site. The arguments are passed to `wp_insert_site()`.
+
+The below example changes the title, path and domain of the site created. These could also be edited via the network admin as well:
+
+```php
+use Altis\Cloud;
+
+add_filter( 'altis.core.global_content_site_menu_pages', function ( array $args ) : array {
+    // Use the subdomain global.example.org.
+    $args['domain'] = sprintf( 'global.%s', parse_url( Cloud\get_main_site_url(), PHP_URL_HOST ) );
+    $args['path'] = '/';
+    $args['title'] = __( 'Shared Content' );
+    return $args;
+} );
+```
 
 **`altis.core.global_content_site_menu_pages : array $pages`**
 

--- a/docs/global-content-repository.md
+++ b/docs/global-content-repository.md
@@ -12,13 +12,31 @@ You might have a user who is an author on the main site, but only a subscriber t
 
 Conversely you may have a user who does not have access to your primary site but who can create and edit content on the Global Content Repository.
 
+## Functions
+
+**`Altis\Global_Content\get_site_id() : ?int`**
+
+Returns the Global Content Repository site ID or null if it doesn't exist yet.
+
+**`Altis\GlobaL_Content\get_site_url() : ?string`**
+
+Returns the Global Content Repository site URL or null if it doesn't exist yet.
+
+**`Altis\Global_Content\is_global_site( ?int $site_id = null ) : bool`**
+
+Returns `true` if the current site is the Global Content Repository or if the site with the passed `$site_id` is.
+
+**`Altis\Global_Content\get_allowed_admin_pages() : array`**
+
+Returns the list of page slugs allowe din the Global Content Repository site admin menu.
+
 ## Filters
 
-**`altis.core.global_content_site_args: array $args`**
+**`altis.core.global_content_site_args : array $args`**
 
 Filters the arguments used to create the Global Content Repository site. The arguments are passed to `wp_insert_site()`.
 
-**`altis.core.global_content_site_menu_pages: array $pages`**
+**`altis.core.global_content_site_menu_pages : array $pages`**
 
 Filters the allowed top level admin menu pages. Defaults to `[ 'users.php' ]`. To add support for pages you could use the following code:
 

--- a/docs/global-content-repository.md
+++ b/docs/global-content-repository.md
@@ -1,0 +1,31 @@
+# Global Content Repository
+
+Altis includes a Global Content Repository framework. This is a site on the network that can be used to distribute content elsewhere via the REST API or directly to other sites on the network.
+
+By default the Global Content Repository only exposes the user management admin. Other Altis modules may extend this, for example [the Altis Media module has a Global Media Library feature](docs://media/global-media-library.md) built on top of the Global Content Repository that allows for uploading media files and accessing them from all sites on the network.
+
+## User Management
+
+Users on the multisite network can have different roles on different sites. This gives you control over who can add and edit global content versus who can only use the global content on their own site.
+
+You might have a user who is an author on the main site, but only a subscriber to the Global Content Repository meaning they could read content to use in their posts but not create or edit global content.
+
+Conversely you may have a user who does not have access to your primary site but who can create and edit content on the Global Content Repository.
+
+## Filters
+
+**`altis.core.global_content_site_args: array $args`**
+
+Filters the arguments used to create the Global Content Repository site. The arguments are passed to `wp_insert_site()`.
+
+**`altis.core.global_content_site_menu_pages: array $pages`**
+
+Filters the allowed top level admin menu pages. Defaults to `[ 'users.php' ]`. To add support for pages you could use the following code:
+
+```php
+add_filter( 'altis.core.global_content_site_menu_pages', function ( array $pages ) : array {
+    $pages[] = 'edit.php?post_type=page';
+    $pages[] = 'post-new.php?post_type=page';
+    return $pages;
+} );
+```

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -25,7 +25,7 @@ class Command extends WP_CLI_Command {
 	 * @param array $assoc_args Command associative arguments.
 	 */
 	public function migrate( array $args, array $assoc_args ) {
-		WP_CLI::success( 'Running Altis migration scripts...' );
+		WP_CLI::log( 'Running Altis migration scripts...' );
 
 		/**
 		 * Triggered by the `wp altis migrate` command. Attach any custom

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -27,6 +27,9 @@ class Command extends WP_CLI_Command {
 	public function migrate( array $args, array $assoc_args ) {
 		WP_CLI::log( 'Running Altis migration scripts...' );
 
+		// Ensure the database is up to date.
+		WP_CLI::runcommand( 'core update-db --network' );
+
 		/**
 		 * Triggered by the `wp altis migrate` command. Attach any custom
 		 * behaviour you need to run post deployment or upgrade.

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Altis WP CLI Command.
+ *
+ * @package altis/core
+ */
+
+namespace Altis;
+
+use WP_CLI;
+use WP_CLI_Command;
+
+/**
+ * Altis WP CLI Command class.
+ */
+class Command extends WP_CLI_Command {
+
+	/**
+	 * Run migration scripts.
+	 *
+	 * This command should be called after upgrading Altis to set up Altis features.
+	 * Custom code can hook into this command using the `altis.migrate` hook.
+	 *
+	 * @param array $args Command arguments.
+	 * @param array $assoc_args Command associative arguments.
+	 */
+	public function migrate( array $args, array $assoc_args ) {
+		WP_CLI::success( 'Running Altis migration scripts...' );
+
+		/**
+		 * Triggered by the `wp altis migrate` command. Attach any custom
+		 * behaviour you need to run post deployment or upgrade.
+		 *
+		 * @param array $args Any plain args passed to the command e.g. `wp altis migrate myarg`.
+		 * @param array $assoc_args Any named arguments passed to the command e.g. `wp altis migrate --url=example.org`.
+		 */
+		do_action( 'altis.migrate', $args, $assoc_args );
+	}
+
+}

--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -1,0 +1,351 @@
+<?php
+/**
+ * Altis Global Content Repository.
+ *
+ * @package altis/core
+ */
+
+namespace Altis\Global_Content;
+
+use Exception;
+use WP_Admin_Bar;
+use WP_CLI;
+use WP_Site;
+
+/**
+ * Setup global media hooks.
+ *
+ * @return void
+ */
+function bootstrap() : void {
+	// Create the site on upgrade.
+	add_action( 'altis.migrate', __NAMESPACE__ . '\\maybe_create_site' );
+
+	// Bootstrap media site if it exists.
+	add_action( 'muplugins_loaded', __NAMESPACE__ . '\\bootstrap_site', 1 );
+}
+
+/**
+ * Add global content site hooks.
+ *
+ * @return void
+ */
+function bootstrap_site() : void {
+	if ( defined( 'WP_INITIAL_INSTALL' ) && WP_INITIAL_INSTALL ) {
+		return;
+	}
+
+	if ( empty( get_site_id() ) ) {
+		return;
+	}
+
+	// Redirect global site URLs.
+	add_action( 'admin_init', __NAMESPACE__ . '\\redirect_admin_pages' );
+	add_action( 'template_redirect', __NAMESPACE__ . '\\redirect_frontend' );
+
+	// Handle clean up operations.
+	add_action( 'wp_uninitialize_site', __NAMESPACE__ . '\\uninitialize_media_site' );
+
+	// Handle global content repo admin customisations.
+	add_action( 'admin_menu', __NAMESPACE__ . '\\admin_menu', 1000 );
+	add_action( 'admin_bar_menu', __NAMESPACE__ . '\\admin_bar_menu', 1000 );
+
+	// Handle global site URL changes.
+	add_action( 'updated_option_siteurl', __NAMESPACE__ . '\\handle_siteurl_update', 10, 2 );
+	add_action( 'updated_option_home', __NAMESPACE__ . '\\handle_siteurl_update', 10, 2 );
+	add_action( 'wp_update_site', __NAMESPACE__ . '\\handle_site_update' );
+
+	// Do not allow global site deletion.
+	add_filter( 'map_meta_cap', __NAMESPACE__ . '\\prevent_site_deletion', 10, 4 );
+
+	// Handle network admin sites list.
+	add_filter( 'manage_sites_action_links', __NAMESPACE__ . '\\sites_list_row_actions', 10, 2 );
+	add_filter( 'display_site_states', __NAMESPACE__ . '\\add_global_site_state', 10, 2 );
+}
+
+/**
+ * Get the global content repository site ID.
+ *
+ * @return integer|null
+ */
+function get_site_id() : ?int {
+	return get_site_option( 'global_content_site_id', null );
+}
+
+/**
+ * Get the global content repository site URL.
+ *
+ * @return string|null
+ */
+function get_site_url() : ?string {
+	return get_site_option( 'global_content_site_url', null );
+}
+
+/**
+ * Returns true if the current site is the global media site.
+ *
+ * @param int|null $site_id An optional site ID to check. Defaults to the current site.
+ * @return boolean
+ */
+function is_global_site( ?int $site_id = null ) : bool {
+	return ! empty( get_site_meta( $site_id ?? get_current_blog_id(), 'is_global_site' ) );
+}
+
+/**
+ * Create the Global Content site.
+ *
+ * @throws Exception If site cannot be created.
+ */
+function maybe_create_site() {
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		WP_CLI::log( 'Creating Global Content Repository site...' );
+	}
+
+	// Check if site exists.
+	if ( ! empty( get_site_id() ) ) {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::log( 'Global Content Repository site exists, skipping.' );
+		}
+		return;
+	}
+
+	/**
+	 * Filters the args used to create the global content site.
+	 *
+	 * @param array $global_site_args The arguments array for creating the global content site.
+	 */
+	$global_site_args = apply_filters( 'altis.core.global_content_site_args', [
+		'domain' => wp_parse_url( home_url(), PHP_URL_HOST ),
+		'path' => '/repo/',
+		'title' => __( 'Global Content Repository', 'altis' ),
+		'user_id' => get_user_by( 'login', get_super_admins()[0] )->ID,
+		'meta' => [
+			'is_global_site' => true,
+		],
+	] );
+
+	$site_id = wp_insert_site( $global_site_args );
+
+	if ( is_wp_error( $site_id ) ) {
+		/**
+		 * The error response.
+		 *
+		 * @var \WP_Error $site_id
+		 */
+		throw new Exception( sprintf( 'Global media site could not be created. %s', $site_id->get_error_message() ) );
+	}
+
+	// Store the site URL and ID.
+	$site_url = get_site_url( $site_id );
+	update_site_option( 'global_content_site_url', rtrim( $site_url, '/' ) );
+	update_site_option( 'global_content_site_id', $site_id );
+
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		WP_CLI::success( 'Global Content Repository site created!' );
+	}
+}
+
+/**
+ * Handle deletion of media site.
+ *
+ * @return void
+ */
+function uninitialize_media_site() {
+	if ( ! is_global_site() ) {
+		return;
+	}
+
+	delete_site_option( 'global_content_site_url' );
+	delete_site_option( 'global_content_site_id' );
+}
+
+/**
+ * Get the allowed admin menu pages for the global site.
+ *
+ * @return array
+ */
+function get_allowed_admin_pages() : array {
+	/**
+	 * Filters the admin menu pages allowed on the Global Media Site admin menu.
+	 *
+	 * @param array $allowed_menu_pages The page slugs allowed in the global media site admin menu.
+	 */
+	$allowed_menu_pages = (array) apply_filters( 'altis.core.global_content_site_menu_pages', [] );
+
+	// Always allow users.php.
+	$allowed_menu_pages[] = 'users.php';
+
+	return $allowed_menu_pages;
+}
+
+/**
+ * Trim down the global site's admin menu.
+ *
+ * @return void
+ */
+function admin_menu() : void {
+	global $menu;
+
+	if ( ! is_global_site() ) {
+		return;
+	}
+
+	$allowed_menu_pages = get_allowed_admin_pages();
+
+	foreach ( $menu as $position => $item ) {
+		if ( ! in_array( $item[2], $allowed_menu_pages, true ) ) {
+			unset( $menu[ $position ] );
+		}
+	}
+}
+
+/**
+ * Modify the admin bar for the media site.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The menu bar control.
+ * @return void
+ */
+function admin_bar_menu( WP_Admin_Bar $wp_admin_bar ) : void {
+
+	$wp_admin_bar->remove_node( sprintf( 'blog-%d-n', get_site_id() ) );
+	$wp_admin_bar->remove_node( sprintf( 'blog-%d-c', get_site_id() ) );
+	$wp_admin_bar->remove_node( sprintf( 'blog-%d-v', get_site_id() ) );
+
+	if ( ! is_global_site() ) {
+		return;
+	}
+
+	// Remove content and front end related menus.
+	$wp_admin_bar->remove_menu( 'new-content' );
+	$wp_admin_bar->remove_menu( 'comments' );
+	$wp_admin_bar->remove_node( 'view-site' );
+
+	// Add the site title in as static text.
+	$wp_admin_bar->add_menu( [
+		'id' => 'site-name',
+		'title' => get_option( 'blogname' ),
+		'href' => false,
+	] );
+}
+
+/**
+ * Filter the site row actions in network admin to prevent deletion.
+ *
+ * @param array $actions The action links array.
+ * @param integer $site_id The site ID.
+ * @return array
+ */
+function sites_list_row_actions( array $actions, int $site_id ) : array {
+	if ( ! is_global_site( $site_id ) ) {
+		return $actions;
+	}
+
+	unset( $actions['deactivate'] );
+	unset( $actions['archive'] );
+	unset( $actions['delete'] );
+	unset( $actions['visit'] );
+
+	return $actions;
+}
+
+/**
+ * Filters the default site display states for items in the Sites list table.
+ *
+ * @param array $site_states An array of site states.
+ * @param WP_Site $site The current site object.
+ * @return array An array of site states.
+ */
+function add_global_site_state( array $site_states, WP_Site $site ) : array {
+	if ( is_global_site( $site->id ) ) {
+		$site_states[] = __( 'Global Content Repository', 'altis' );
+	}
+
+	return $site_states;
+}
+
+/**
+ * Redirect to the first allowed menu page for the global site.
+ *
+ * @return void
+ */
+function redirect_admin_pages() : void {
+	global $pagenow;
+
+	if ( ! is_global_site() ) {
+		return;
+	}
+
+	if ( in_array( $pagenow, get_allowed_admin_pages(), true ) ) {
+		return;
+	}
+
+	wp_safe_redirect( admin_url( get_allowed_admin_pages()[0] ) );
+	exit;
+}
+
+/**
+ * Redirect to the media library from the media site frontend.
+ *
+ * @return void
+ */
+function redirect_frontend() : void {
+	if ( ! is_global_site() ) {
+		return;
+	}
+
+	if ( is_admin() ) {
+		return;
+	}
+
+	wp_safe_redirect( admin_url( get_allowed_admin_pages()[0] ) );
+	exit;
+}
+
+/**
+ * Update netowrk option on site URL changes.
+ *
+ * @param string $old_value The old option value.
+ * @param string $value The new option value.
+ * @return void
+ */
+function handle_siteurl_update( $old_value, $value ) : void {
+	update_site_option( 'global_content_site_url', untrailingslashit( $value ) );
+}
+
+/**
+ * Handle updating the global media site URL when edited from the network settings.
+ *
+ * @param WP_Site $site The site object.
+ * @return void
+ */
+function handle_site_update( WP_Site $site ) : void {
+	if ( ! is_global_site( $site->id ) ) {
+		return;
+	}
+
+	// Build the new site URL as the new value isn't cached yet for get_site_url().
+	$new_site_url = set_url_scheme( sprintf( 'https://%s%s', $site->domain, $site->path ) );
+
+	update_site_option( 'global_content_site_url', untrailingslashit( $new_site_url ) );
+}
+
+/**
+ * Prevent users deleting the global media site.
+ *
+ * @param string[] $caps Primitive capabilities required of the user.
+ * @param string $cap Capability being checked.
+ * @param int $user_id The user ID.
+ * @param array $args Adds context to the capability check, typically starting with an object ID.
+ * @return string[] Primitive capabilities required of the user.
+ */
+function prevent_site_deletion( array $caps, string $cap, int $user_id, array $args ) : array {
+	if ( $cap !== 'delete_site' ) {
+		return $caps;
+	}
+
+	if ( ! isset( $args[0] ) || intval( $args[0] ) !== (int) get_site_option( 'global_content_site_id' ) ) {
+		return $caps;
+	}
+
+	return [ 'do_not_allow' ];
+}

--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -319,7 +319,7 @@ function redirect_frontend() : void {
 }
 
 /**
- * Update netowrk option on site URL changes.
+ * Update network option on site URL changes.
  *
  * @param string $old_value The old option value.
  * @param string $value The new option value.

--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -118,21 +118,17 @@ function maybe_create_site() {
 		'domain' => wp_parse_url( home_url(), PHP_URL_HOST ),
 		'path' => '/repo/',
 		'title' => __( 'Global Content Repository', 'altis' ),
-		'user_id' => get_user_by( 'login', get_super_admins()[0] )->ID,
-		'meta' => [
-			'is_global_site' => true,
-		],
 	] );
 
 	// Ensure user and global site meta is set.
-	if ( ! isset( $global_site_args['user_id'] ) ) {
-		$global_site_args['user_id'] = get_user_by( 'login', get_super_admins()[0] )->ID;
-	}
-	if ( ! isset( $global_site_args['meta'] ) ) {
-		$global_site_args['meta'] = [];
-	}
+	$global_site_args = wp_parse_args( $global_site_args, [
+		'user_id' => get_user_by( 'login', get_super_admins()[0] )->ID,
+		'meta' => [],
+	] );
+
 	$global_site_args['meta']['is_global_site'] = true;
 
+	// Create the site.
 	$site_id = wp_insert_site( $global_site_args );
 
 	if ( is_wp_error( $site_id ) ) {

--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -124,6 +124,15 @@ function maybe_create_site() {
 		],
 	] );
 
+	// Ensure user and global site meta is set.
+	if ( ! isset( $global_site_args['user_id'] ) ) {
+		$global_site_args['user_id'] = get_user_by( 'login', get_super_admins()[0] )->ID;
+	}
+	if ( ! isset( $global_site_args['meta'] ) ) {
+		$global_site_args['meta'] = [];
+	}
+	$global_site_args['meta']['is_global_site'] = true;
+
 	$site_id = wp_insert_site( $global_site_args );
 
 	if ( is_wp_error( $site_id ) ) {

--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -174,6 +174,9 @@ function get_allowed_admin_pages() : array {
 
 	// Always allow users.php.
 	$allowed_menu_pages[] = 'users.php';
+	$allowed_menu_pages[] = 'profile.php';
+	$allowed_menu_pages[] = 'user-new.php';
+	$allowed_menu_pages[] = 'user-edit.php';
 
 	return $allowed_menu_pages;
 }
@@ -275,7 +278,11 @@ function redirect_admin_pages() : void {
 		return;
 	}
 
-	if ( in_array( $pagenow, get_allowed_admin_pages(), true ) ) {
+	if ( $pagenow !== 'index.php' ) {
+		return;
+	}
+
+	if ( in_array( 'index.php', get_allowed_admin_pages(), true ) ) {
 		return;
 	}
 

--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -136,7 +136,8 @@ function maybe_create_site() {
 	}
 
 	// Store the site URL and ID.
-	$site_url = get_site_url( $site_id );
+	$site = get_site( $site_id );
+	$site_url = set_url_scheme( sprintf( 'https://%s%s', $site->domain, $site->path ) );
 	update_site_option( 'global_content_site_url', rtrim( $site_url, '/' ) );
 	update_site_option( 'global_content_site_id', $site_id );
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -14,6 +14,16 @@ use Aws\Sdk;
  */
 function bootstrap() {
 	About\bootstrap();
+	Global_Content\bootstrap();
+
+	// Register the Altis command.
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		WP_CLI::add_command( 'altis', __NAMESPACE__ . '\\Command' );
+		// Bind the migrate command to run after initial install.
+		WP_CLI::add_hook( 'after_invoke:core multisite-install', function () {
+			WP_CLI::runcommand( 'altis migrate' );
+		} );
+	}
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -8,6 +8,7 @@
 namespace Altis;
 
 use Aws\Sdk;
+use WP_CLI;
 
 /**
  * Bootstrap any core functions as necessary.


### PR DESCRIPTION
This adds the global content repo code and the `wp altis migrate` command necessary to create it.

Related to https://github.com/humanmade/altis-media/issues/100