### PR TITLE
remove post cloner

### DIFF
--- a/inc/composer/class-override-installer.php
+++ b/inc/composer/class-override-installer.php
@@ -92,7 +92,6 @@ class Override_Installer extends BaseInstaller {
 			'johnbillion/query-monitor',
 			'stuttter/ludicrousdb',
 			'stuttter/wp-user-signups',
-			'yoast/duplicate-post',
 		];
 
 		$excluded_plugins = array_unique( array_merge( $legacy, $this->installOverrides ) );

--- a/inc/composer/class-override-installer.php
+++ b/inc/composer/class-override-installer.php
@@ -79,7 +79,6 @@ class Override_Installer extends BaseInstaller {
 			'humanmade/meta-tags',
 			'humanmade/php-basic-auth',
 			'humanmade/publication-checklist',
-			'humanmade/post-cloner',
 			'humanmade/require-login',
 			'humanmade/s3-uploads',
 			'humanmade/smart-media',
@@ -93,6 +92,7 @@ class Override_Installer extends BaseInstaller {
 			'johnbillion/query-monitor',
 			'stuttter/ludicrousdb',
 			'stuttter/wp-user-signups',
+			'yoast/duplicate-post',
 		];
 
 		$excluded_plugins = array_unique( array_merge( $legacy, $this->installOverrides ) );


### PR DESCRIPTION
This updates the composer installer overrides to remove Post Cloner in preparation of replacing with Yoast Duplicate Post.
We don't need to add Yoast Duplicate Post to replace here because manually overriding in the override installer class is no longer required.