### PR TITLE
Make is_global_site() safe to use during install

### DIFF
--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -88,6 +88,10 @@ function get_site_url() : ?string {
  * @return boolean
  */
 function is_global_site( ?int $site_id = null ) : bool {
+	if ( defined( 'WP_INITIAL_INSTALL' ) && WP_INITIAL_INSTALL ) {
+		return;
+	}
+
 	return ! empty( get_site_meta( $site_id ?? get_current_blog_id(), 'is_global_site' ) );
 }
 

--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -89,7 +89,7 @@ function get_site_url() : ?string {
  */
 function is_global_site( ?int $site_id = null ) : bool {
 	if ( defined( 'WP_INITIAL_INSTALL' ) && WP_INITIAL_INSTALL ) {
-		return;
+		return false;
 	}
 
 	return ! empty( get_site_meta( $site_id ?? get_current_blog_id(), 'is_global_site' ) );


### PR DESCRIPTION
In a lot of places it could be called during the installation step and will throw an error due to looking in missing db tables.