### PR TITLE
Pass-through session cookies to global content requests

### DIFF
--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -388,7 +388,7 @@ function filter_global_content_requests_for_auth( array $parsed_args, string $ur
 		return $parsed_args;
 	}
 
-	$parsed_args['cookies'] = array_map( function( $value, $name ) {
+	$parsed_args['cookies'] = array_map( function ( $value, $name ) {
 		return new WP_Http_Cookie( [
 			'name' => $name,
 			'value' => $value,


### PR DESCRIPTION
This copies and passes-through session cookies to any request to global content site, to allow authenticated requests and support private global content sites.

humanmade/altis-media#159