### PR TITLE
Ensure legacy healthcheck succeeds

### DIFF
--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -92,7 +92,7 @@ function get_site_url() : ?string {
  * @return boolean
  */
 function is_global_site( ?int $site_id = null ) : bool {
-	if ( defined( 'WP_INITIAL_INSTALL' ) && WP_INITIAL_INSTALL ) {
+	if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
 		return false;
 	}
 


### PR DESCRIPTION
Need to check if WP is installing at all before calling `get_site_meta()` to prevent a fatal error and churning containers.