### PR TITLE
Forward Authorization to global content repo

### DIFF
--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -396,5 +396,11 @@ function filter_global_content_requests_for_auth( array $parsed_args, string $ur
 		] );
 	}, $_COOKIE, array_keys( $_COOKIE ) );
 
+	// Check for Auth header and forward it, for Basic Auth feature support.
+	if ( ! isset( $parsed_args['headers']['Authorization'] ) && ! empty( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$parsed_args['headers']['Authorization'] = wp_unslash( $_SERVER['HTTP_AUTHORIZATION'] );
+	}
+
 	return $parsed_args;
 }


### PR DESCRIPTION
When using HTTP Basic Auth with the global media feature the requests would fail as the Auth header is missing. This forwards the auth header if found.
Fixes #377