### PR TITLE
Display upgrade notice even on new dash

### DIFF
--- a/inc/upgrades/namespace.php
+++ b/inc/upgrades/namespace.php
@@ -232,12 +232,19 @@ function render_widget() {
 				>
 					<?php
 						// phpcs:ignore
-						echo clean_html( sprintf(
-							'%1$s <span class="screen-reader-text">%2$s</span>',
-							__( 'Learn more about Altis upgrades' ),
-							/* translators: Accessibility text. */
-							__( '(opens in a new tab)' )
-						), 'span' );
+						echo clean_html(
+							sprintf(
+								'%1$s <span class="screen-reader-text">%2$s</span>',
+								__( 'Learn more about Altis upgrades' ),
+								/* translators: Accessibility text. */
+								__( '(opens in a new tab)' )
+							),
+							[
+								'span' => [
+									'class' => true,
+								],
+							]
+						);
 					?>
 					<span aria-hidden="true" class="dashicons dashicons-external"></span>
 				</a>

--- a/inc/upgrades/namespace.php
+++ b/inc/upgrades/namespace.php
@@ -16,6 +16,9 @@ function bootstrap() {
 	add_action( 'load-index.php', __NAMESPACE__ . '\\maybe_render_header', 0 );
 }
 
+/**
+ * Conditionally render the upgrade notice.
+ */
 function maybe_render_header() {
 	if ( ! current_user_can( 'edit_options' ) ) {
 		return;

--- a/inc/upgrades/namespace.php
+++ b/inc/upgrades/namespace.php
@@ -13,14 +13,10 @@ use Altis;
  * Bootstrap the actions.
  */
 function bootstrap() {
-	add_action( 'wp_network_dashboard_setup', __NAMESPACE__ . '\\register_widget' );
-	add_action( 'wp_dashboard_setup', __NAMESPACE__ . '\\register_widget' );
+	add_action( 'load-index.php', __NAMESPACE__ . '\\maybe_render_header', 0 );
 }
 
-/**
- * Register our dashboard widget.
- */
-function register_widget() {
+function maybe_render_header() {
 	if ( ! current_user_can( 'edit_options' ) ) {
 		return;
 	}
@@ -29,61 +25,66 @@ function register_widget() {
 		return;
 	}
 
-	add_action( 'admin_head-index.php', function () {
-		?>
-		<style>
-			#altis-upgrade-warning {
-				position: relative;
-				margin: 40px 0 10px;
-				padding: 8px 12px;
-				border: 2px solid #df3232;
-				border-radius: 1px;
-				box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
-				background: #fff;
-				font-size: 13px;
-				line-height: 1.7;
-			}
-
-			#altis-upgrade-warning h1 {
-				background: #df3232;
-				color: #f0f0f0;
-				padding: 8px 12px;
-				margin: -8px -12px 0;
-				font-weight: bold;
-			}
-
-			#altis-upgrade-warning h1 .dashicons {
-				color: #df3232;
-				color: #f0f0f0;
-				font-size: 23px;
-				height: 23px;
-				width: 23px;
-				line-height: 1.3;
-			}
-
-			#altis-upgrade-warning p {
-				font-size: 14px;
-			}
-
-			#altis-upgrade-warning p:last-of-type {
-				margin-bottom: 4px;
-			}
-
-			#altis-upgrade-warning .button .dashicons-external {
-				line-height: 43px;
-			}
-		</style>
-		<?php
-	} );
-
-	add_action( 'all_admin_notices', function () {
+	add_action( 'admin_head-index.php', __NAMESPACE__ . '\\render_styles' );
+	add_action( 'in_admin_header', function () {
 		global $pagenow;
 		if ( $pagenow !== 'index.php' ) {
 			return;
 		}
 
 		render_widget();
-	} );
+	}, 0 );
+}
+
+/**
+ * Render stylesheet.
+ */
+function render_styles() {
+	?>
+	<style>
+		#altis-upgrade-warning {
+			position: relative;
+			margin: 0;
+			padding: 8px 12px;
+			border: 5px solid #df3232;
+			border-radius: 1px;
+			box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+			background: #fff;
+			font-size: 13px;
+			line-height: 1.7;
+		}
+
+		#altis-upgrade-warning h1 {
+			background: #df3232;
+			color: #fff;
+			padding: 8px 12px;
+			margin: -8px -12px 0;
+			font-weight: bold;
+		}
+
+		#altis-upgrade-warning h1 .dashicons {
+			color: #df3232;
+			color: #fff;
+			font-size: 23px;
+			height: 23px;
+			width: 23px;
+			line-height: 1.3;
+			vertical-align: baseline;
+		}
+
+		#altis-upgrade-warning p {
+			font-size: 14px;
+		}
+
+		#altis-upgrade-warning p:last-of-type {
+			margin-bottom: 4px;
+		}
+
+		#altis-upgrade-warning .button .dashicons-external {
+			line-height: 43px;
+		}
+	</style>
+	<?php
 }
 
 /**
@@ -193,7 +194,6 @@ function render_widget() {
 	$latest = $releases[0];
 
 	?>
-	<div class="wrap">
 		<div id="altis-upgrade-warning">
 			<h1>
 				<span aria-hidden="true" class="dashicons dashicons-warning"></span>
@@ -243,6 +243,5 @@ function render_widget() {
 				</a>
 			</p>
 		</div>
-	</div>
 	<?php
 }


### PR DESCRIPTION
Fixes #397.

New Dash | Network Dash (or Old Dash)
-- | --
![Screenshot 2022-02-11 at 12-14-06 Home ‹ Altis — Altis](https://user-images.githubusercontent.com/21655/153589801-ca37aa54-d964-461d-9f31-efe9bd6a073c.png) | ![Screenshot 2022-02-11 at 12-14-43 Dashboard ‹ Network Admin Altis Sites — Altis](https://user-images.githubusercontent.com/21655/153589869-5d044c7e-3a09-4ab7-b834-fdc989d79b43.png)

It's a little ugly on the old dash, but to fix that we'd need a dependency between the analytics and the core module. IMO, it's acceptable.