### PR TITLE
Global Content Repository urls

### DIFF
--- a/docs/global-content-repository.md
+++ b/docs/global-content-repository.md
@@ -6,7 +6,7 @@ By default the Global Content Repository only exposes the user management admin.
 
 The Global Content Repository site is set to be a private site by default. This can be modified by switching the site to a public one from the Network Admin > Sites management page, clicking `Edit` on the site, and checking the `Public` checkbox.
 
-**Note:**When using media from the Global Content Repository, the URL for the selected media will always be relative to that of your Global Content Repository site and not the site it's being displayed on.
+**Note:** When using media from the Global Content Repository, the URL for the selected media will always be relative to that of your Global Content Repository site and not the site it's being displayed on.
 
 ## User Management
 

--- a/docs/global-content-repository.md
+++ b/docs/global-content-repository.md
@@ -6,7 +6,7 @@ By default the Global Content Repository only exposes the user management admin.
 
 The Global Content Repository site is set to be a private site by default. This can be modified by switching the site to a public one from the Network Admin > Sites management page, clicking `Edit` on the site, and checking the `Public` checkbox.
 
-When using media from the Global Content Repository, the url for the selected media will always be relevant to that of your Global Content Repository site and not the site it's being displayed on.
+**Note:**When using media from the Global Content Repository, the URL for the selected media will always be relative to that of your Global Content Repository site and not the site it's being displayed on.
 
 ## User Management
 

--- a/docs/global-content-repository.md
+++ b/docs/global-content-repository.md
@@ -6,6 +6,8 @@ By default the Global Content Repository only exposes the user management admin.
 
 The Global Content Repository site is set to be a private site by default. This can be modified by switching the site to a public one from the Network Admin > Sites management page, clicking `Edit` on the site, and checking the `Public` checkbox.
 
+When using media from the Global Content Repository, the url for the selected media will always be relevant to that of your Global Content Repository site and not the site it's being displayed on.
+
 ## User Management
 
 Users on the multisite network can have different roles on different sites. This gives you control over who can add and edit global content versus who can only use the global content on their own site.


### PR DESCRIPTION
Added a brief note that informs users that when using content from the Global Content Repository, that the URL's will be relevant to the Global Content Repository and not the site it's being displayed on.

linked issue #418 