### PR TITLE
Add support for CI environment type

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Returns the current hosting stack name based on the `HM_ENV` constant. On local 
 
 **`get_environment_type() : string`**
 
-Returns one of `local`, `development`, `staging` or `production`. This is read from the `HM_ENV_TYPE` constant except on local setups.
+Returns one of `local`, `ci`, `development`, `staging` or `production`. This is read from the `HM_ENV_TYPE` constant except on local setups. CI environments are checked via the `CI` environment variable, which is set for a number of CI/CD service tools (e.g. Travis CI, CircleCI, GitHub Actions).
 
 **`get_environment_region() : ?string`**
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -334,11 +334,14 @@ function get_environment_name() : string {
 /**
  * Get the type of the current environment.
  *
- * Can be "local", "development", "staging", "production" etc.
+ * Can be "local", "ci", "development", "staging", "production" etc.
  *
  * @return string
  */
 function get_environment_type() : string {
+	if ( getenv( 'CI' ) ) {
+		return 'ci';
+	}
 	if ( defined( 'HM_ENV_TYPE' ) ) {
 		return HM_ENV_TYPE;
 	}


### PR DESCRIPTION
This PR updates the `get_environment_type` function so that it returns `ci` based on non-emptiness of the `CI` environment variable. This variable is used by a number of CI/CD tools, including [Travis CI](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables), [CircleCI](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables) and [GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables), just to name a few that have been or still are in frequent use.