### PR TITLE
Update Segment tracking with the page title.

### DIFF
--- a/inc/telemetry/namespace.php
+++ b/inc/telemetry/namespace.php
@@ -299,12 +299,23 @@ function get_environment_details() : array {
  * @return void
  */
 function load_segment_js() {
+	$page_name = get_admin_page_title();
+	switch ( $page_name ) {
+		case 'Home':
+			$page_name = 'Dashboard';
+			break;
+		case 'Welcome':
+			$page_name = 'Developer Documentation';
+			break;
+		default:
+			$page_name;
+	}
 	?>
 	<script>
 		// Segment - Load
 		!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="<?php echo esc_js( get_segment_id() ); ?>";analytics.SNIPPET_VERSION="4.13.2";
 			analytics.load( <?php echo wp_json_encode( get_segment_id() ) ?> );
-			analytics.page();
+			analytics.page( "<?php echo $page_name ;?>" );
 		}}();
 	</script>
 	<?php

--- a/inc/telemetry/namespace.php
+++ b/inc/telemetry/namespace.php
@@ -299,16 +299,10 @@ function get_environment_details() : array {
  * @return void
  */
 function load_segment_js() {
-	$page_name = get_admin_page_title();
-	switch ( $page_name ) {
-		case 'Home':
-			$page_name = 'Dashboard';
-			break;
-		case 'Welcome':
-			$page_name = 'Developer Documentation';
-			break;
-		default:
-			$page_name;
+	if ( isset( $_GET['page'] ) ){
+		$page_name = str_replace( '-', ' ', ucfirst( $_GET['page'] ) );
+	} else {
+		$page_name = get_admin_page_title();
 	}
 	?>
 	<script>

--- a/inc/telemetry/namespace.php
+++ b/inc/telemetry/namespace.php
@@ -298,18 +298,12 @@ function get_environment_details() : array {
  *
  * @return void
  */
-function load_segment_js() {
-	if ( isset( $_GET['page'] ) ){
-		$page_name = str_replace( '-', ' ', ucfirst( $_GET['page'] ) );
-	} else {
-		$page_name = get_admin_page_title();
-	}
-	?>
+function load_segment_js() { ?>
 	<script>
 		// Segment - Load
 		!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="<?php echo esc_js( get_segment_id() ); ?>";analytics.SNIPPET_VERSION="4.13.2";
 			analytics.load( <?php echo wp_json_encode( get_segment_id() ) ?> );
-			analytics.page( "<?php echo esc_js( $page_name ); ?>" );
+			analytics.page( "<?php echo esc_js( get_admin_page_title() ); ?>" );
 		}}();
 	</script>
 	<?php

--- a/inc/telemetry/namespace.php
+++ b/inc/telemetry/namespace.php
@@ -315,7 +315,7 @@ function load_segment_js() {
 		// Segment - Load
 		!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="<?php echo esc_js( get_segment_id() ); ?>";analytics.SNIPPET_VERSION="4.13.2";
 			analytics.load( <?php echo wp_json_encode( get_segment_id() ) ?> );
-			analytics.page( "<?php echo $page_name ;?>" );
+			analytics.page( "<?php echo $page_name; ?>" );
 		}}();
 	</script>
 	<?php

--- a/inc/telemetry/namespace.php
+++ b/inc/telemetry/namespace.php
@@ -298,7 +298,8 @@ function get_environment_details() : array {
  *
  * @return void
  */
-function load_segment_js() { ?>
+function load_segment_js() {
+	?>
 	<script>
 		// Segment - Load
 		!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="<?php echo esc_js( get_segment_id() ); ?>";analytics.SNIPPET_VERSION="4.13.2";

--- a/inc/telemetry/namespace.php
+++ b/inc/telemetry/namespace.php
@@ -315,7 +315,7 @@ function load_segment_js() {
 		// Segment - Load
 		!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="<?php echo esc_js( get_segment_id() ); ?>";analytics.SNIPPET_VERSION="4.13.2";
 			analytics.load( <?php echo wp_json_encode( get_segment_id() ) ?> );
-			analytics.page( "<?php echo $page_name; ?>" );
+			analytics.page( "<?php echo esc_js( $page_name ); ?>" );
 		}}();
 	</script>
 	<?php


### PR DESCRIPTION
Issue - [Update Segment Tracking for page view event in Altis #1038](https://github.com/humanmade/product-dev/issues/1038)

This PR adds the admin page title to the default Segment.io tracking.

By default `get_admin_page_title()` returns **Home** for the **Dashboard** and **Welcome** for the **Developer Documentation**  page.

I have included a switch statement to return **Dashboard** and **Developer Documentation**  for the relevant pages.