### PR TITLE
Fix parsing of installed.json for Composer 1.x

### DIFF
--- a/tests/acceptance/AdminCest.php
+++ b/tests/acceptance/AdminCest.php
@@ -17,6 +17,8 @@ class AdminCest {
 	 *
 	 * @param AcceptanceTester $I Tester
 	 *
+	 * @throws \Exception if Composer's installed.json file could not be parsed.
+	 *
 	 * @return void
 	 */
 	public function moduleVersionsDisplayed( AcceptanceTester $I ) {

--- a/tests/acceptance/AdminCest.php
+++ b/tests/acceptance/AdminCest.php
@@ -26,7 +26,14 @@ class AdminCest {
 		$I->see( 'Current Module Versions' );
 
 		$composer = json_decode( file_get_contents( 'vendor/composer/installed.json' ) );
-		$packages = $composer->packages;
+
+		if ( isset( $composer->packages ) ) {
+			$packages = $composer->packages;
+		} elseif ( is_array( $composer ) ) {
+			$packages = $composer;
+		} else {
+			throw new \Exception( 'Unable to parse Composer\'s installed.json' );
+		}
 
 		$modules = [
 			'altis/cms' => [ 'name' => 'CMS' ],


### PR DESCRIPTION
Before 2.x Composer's installed.json looked slightly different. Tests in this module are currently failing with Composer 1.x because of the difference in format. This commit adds support for both versions.

Here's the current output from Travis under Composer 1.x:

```
1) AdminCest: Test About page shows correct module versions.
 Test  [secure]/core/tests/acceptance/AdminCest.php:moduleVersionsDisplayed
                                                                                    
  [PHPUnit\Framework\Error\Notice] Trying to get property 'packages' of non-object  
                                                                                    
Scenario Steps:
 3. $I->see("Current Module Versions") at [secure]/core/tests/acceptance/AdminCest.php:26
 2. $I->amOnAdminPage("about.php") at [secure]/core/tests/acceptance/AdminCest.php:25
 1. $I->loginAsAdmin() at [secure]/core/tests/acceptance/AdminCest.php:24
#1  /usr/src/app/vendor/[secure]/core/tests/acceptance/AdminCest.php:29
#2  AdminCest->moduleVersionsDisplayed
```