### PR TITLE
Show the error in WP-CLI when creating the global media site fails

### DIFF
--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -148,12 +148,21 @@ function maybe_create_site() {
 	$site_id = wp_insert_site( $global_site_args );
 
 	if ( is_wp_error( $site_id ) ) {
+		$message = sprintf(
+			'Global media site could not be created. %s',
+			$site_id->get_error_message()
+		);
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::error( $message );
+		}
+
 		/**
 		 * The error response.
 		 *
 		 * @var \WP_Error $site_id
 		 */
-		throw new Exception( sprintf( 'Global media site could not be created. %s', $site_id->get_error_message() ) );
+		throw new Exception( $message );
 	}
 
 	// Store the site URL and ID.


### PR DESCRIPTION
WP-CLI doesn't catch and display the message from an exception, so `WP_CLI::error()` needs to be called explicitly. This was causing an error from the global media site creation to not appear in the output when updating Altis with `composer server cli -- altis migrate`.

## Before:

```
Success: WordPress database upgraded on 2/2 sites.
Creating Global Content Repository site...
```

## After:

```
Success: WordPress database upgraded on 2/2 sites.
Creating Global Content Repository site...
Error: Global media site could not be created. Sorry, that site already exists!
```