### PR TITLE
Fix Linter Error on Comment style

### DIFF
--- a/tests/acceptance/AdminCest.php
+++ b/tests/acceptance/AdminCest.php
@@ -17,7 +17,7 @@ class AdminCest {
 	 *
 	 * @param AcceptanceTester $I Tester
 	 *
-	 * @throws \Exception if Composer's installed.json file could not be parsed.
+	 * @throws \Exception If Composer's installed.json file could not be parsed.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
The `@throws` tag comment wasn't captialised