### PR TITLE
Don't show the upgrade notice for beta versions.

### DIFF
--- a/inc/upgrades/namespace.php
+++ b/inc/upgrades/namespace.php
@@ -129,7 +129,7 @@ function is_version_latest() : bool {
 	}
 
 	$releases = get_supported_version_info();
-	return $version === ( $releases[0]['version'] ?? $version );
+	return ( $version >= $releases[0]['version'] ?? false );
 }
 
 /**

--- a/inc/upgrades/namespace.php
+++ b/inc/upgrades/namespace.php
@@ -129,7 +129,7 @@ function is_version_latest() : bool {
 	}
 
 	$releases = get_supported_version_info();
-	return ( $version >= $releases[0]['version'] ?? false );
+	return $version >= ( $releases[0]['version'] ?? $version );
 }
 
 /**

--- a/inc/upgrades/namespace.php
+++ b/inc/upgrades/namespace.php
@@ -352,13 +352,6 @@ function render_upgrade_widget() {
 	}
 
 	$latest = $releases[0];
-	$current = get_current_version_info();
-
-	// Return early for versions greater or equal to the latest version.
-	if ( $current['version'] >= $latest['version'] ) {
-		return;
-	}
-
 	$link = $latest['blog'] ?: "https://github.com/humanmade/altis/releases/tag/{$latest['tag']}";
 	$img = $latest['prompt_image'] ?? 'https://www.altis-dxp.com/tachyon/2021/08/Marketer-Experience-1.png';
 	$message = $latest['prompt'] ?? sprintf(

--- a/inc/upgrades/namespace.php
+++ b/inc/upgrades/namespace.php
@@ -352,6 +352,13 @@ function render_upgrade_widget() {
 	}
 
 	$latest = $releases[0];
+	$current = get_current_version_info();
+
+	// Return early for versions greater or equal to the latest version.
+	if ( $current >= $latest['version'] ) {
+		return;
+	}
+
 	$link = $latest['blog'] ?: "https://github.com/humanmade/altis/releases/tag/{$latest['tag']}";
 	$img = $latest['prompt_image'] ?? 'https://www.altis-dxp.com/tachyon/2021/08/Marketer-Experience-1.png';
 	$message = $latest['prompt'] ?? sprintf(

--- a/inc/upgrades/namespace.php
+++ b/inc/upgrades/namespace.php
@@ -355,7 +355,7 @@ function render_upgrade_widget() {
 	$current = get_current_version_info();
 
 	// Return early for versions greater or equal to the latest version.
-	if ( $current >= $latest['version'] ) {
+	if ( $current['version'] >= $latest['version'] ) {
 		return;
 	}
 


### PR DESCRIPTION
Related issue - #453 

Currently when on a beta version of Altis, the upgrade notice is shown. 

This PR ensures that when your "current" version of Altis, is equal to or greater than the "latest" version you won't be shown the upgrade notice.