### PR TITLE
Pin aws/aws-sdk-php to allow patch increments only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=7.1",
-		"aws/aws-sdk-php": "^3.242.1",
+		"aws/aws-sdk-php": "~3.242.1",
 		"composer-plugin-api": "^1.1 || ^2.0",
 		"composer/installers": "^1.12 || ^2.0",
 		"segmentio/analytics-php": "~2.0.0"


### PR DESCRIPTION
A change in the AWS SDK version 3.243.0 introduced a new class to construct dynamic endpoints, which caused problems with S3 Uploads. Let's pin the SDK version to an earlier version and allow patch increments only, and have Dependabot handle the rest.

See:

* https://github.com/aws/aws-sdk-php/issues/2563
* https://github.com/humanmade/altis-local-server/issues/542