### PR TITLE
Issue 1261 remove gaussian lazy loading

### DIFF
--- a/inc/composer/class-override-installer.php
+++ b/inc/composer/class-override-installer.php
@@ -71,7 +71,6 @@ class Override_Installer extends BaseInstaller {
 			'humanmade/cavalcade',
 			'humanmade/debug-bar-elasticpress',
 			'humanmade/delegated-oauth',
-			'humanmade/gaussholder',
 			'humanmade/hm-gtm',
 			'humanmade/hm-redirects',
 			'humanmade/hm-limit-login-attempts',

--- a/tests/acceptance/AdminCest.php
+++ b/tests/acceptance/AdminCest.php
@@ -48,7 +48,6 @@ class AdminCest {
 			'altis/local-chassis' => [ 'name' => 'Local Chassis' ],
 			'altis/local-server' => [ 'name' => 'Local Server' ],
 			'altis/media' => [ 'name' => 'Media' ],
-			'altis/multilingual' => [ 'name' => 'Multilingual' ],
 			'altis/privacy' => [ 'name' => 'Privacy' ],
 			'altis/security' => [ 'name' => 'Security' ],
 			'altis/seo' => [ 'name' => 'SEO' ],


### PR DESCRIPTION
Removes the Gaussian lazy loading module in favour of WordPress' built in functionality.
