### PR TITLE
Allow composer/installers version 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"php": ">=7.1",
 		"aws/aws-sdk-php": "~3.258.8",
 		"composer-plugin-api": "^1.1 || ^2.0",
-		"composer/installers": "^2.2.0",
+		"composer/installers": "^1.12 || ^2.2.0",
 		"segmentio/analytics-php": "~3.5.0"
 	},
 	"autoload": {


### PR DESCRIPTION
Some other dependencies are still explicitly requiring 1.x so we're not quite ready to force 2.x yet.