### PR TITLE
Remove altis/local-chassis module from admin tests

### DIFF
--- a/tests/acceptance/AdminCest.php
+++ b/tests/acceptance/AdminCest.php
@@ -39,6 +39,7 @@ class AdminCest {
 
 		$modules = [
 			'altis/cms' => [ 'name' => 'CMS' ],
+			'altis/analytics' => [ 'name' => 'Analytics' ],
 			'altis/cloud' => [ 'name' => 'Cloud' ],
 			'altis/core' => [ 'name' => 'Core' ],
 			'altis/dev-tools' => [ 'name' => 'Developer Tools' ],

--- a/tests/acceptance/AdminCest.php
+++ b/tests/acceptance/AdminCest.php
@@ -39,13 +39,11 @@ class AdminCest {
 
 		$modules = [
 			'altis/cms' => [ 'name' => 'CMS' ],
-			'altis/analytics' => [ 'name' => 'Analytics' ],
 			'altis/cloud' => [ 'name' => 'Cloud' ],
 			'altis/core' => [ 'name' => 'Core' ],
 			'altis/dev-tools' => [ 'name' => 'Developer Tools' ],
 			'altis/documentation' => [ 'name' => 'Documentation' ],
 			'altis/enhanced-search' => [ 'name' => 'Search' ],
-			'altis/local-chassis' => [ 'name' => 'Local Chassis' ],
 			'altis/local-server' => [ 'name' => 'Local Server' ],
 			'altis/media' => [ 'name' => 'Media' ],
 			'altis/privacy' => [ 'name' => 'Privacy' ],


### PR DESCRIPTION
The altis/local-chassis module no longer ships with Altis and causes tests to fail as there is no version.