### PR TITLE
Introduce a JSON schema for composer.json

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,149 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://schemas.altis-dxp.com/schema.json",
+	"title": "Altis Core schema for composer.json",
+	"type": "object",
+	"definitions": {
+		"altis-modules": {
+			"title": "Configuration for Altis modules",
+			"description": "https://docs.altis-dxp.com/getting-started/configuration/",
+			"type": "object",
+			"properties": {
+				"analytics": {
+					"title": "Analytics module for Altis",
+					"description": "https://docs.altis-dxp.com/analytics/",
+					"type": "object",
+					"properties": {
+						"enabled": {
+							"description": "Whether this module is enabled",
+							"type": "boolean",
+							"default": true
+						},
+						"native": {
+							"description": "Whether to use native analytics",
+							"type": "boolean",
+							"default": true
+						}
+					}
+				},
+				"cms": {
+					"title": "CMS module for Altis",
+					"description": "https://docs.altis-dxp.com/cms/",
+					"type": "object",
+					"properties": {
+						"enabled": {
+							"description": "Whether this module is enabled",
+							"type": "boolean",
+							"default": true
+						},
+						"xmlrpc": {
+							"description": "Whether the XML-RPC API is enabled",
+							"type": "boolean",
+							"default": true
+						},
+						"shared-blocks": {
+							"description": "Whether shared blocks are enabled",
+							"type": "boolean",
+							"default": true
+						},
+						"favicon": {
+							"title": "Custom Favicon",
+							"description": "A project root relative path to an image file, or boolean false to disable the custom favicon",
+							"type": [
+								"string",
+								"boolean"
+							]
+						}
+					}
+				},
+				"dev-tools": {
+					"title": "Dev tools module for Altis",
+					"description": "https://docs.altis-dxp.com/dev-tools/",
+					"type": "object",
+					"properties": {
+						"enabled": {
+							"description": "Whether this module is enabled",
+							"type": "boolean",
+							"default": true
+						},
+						"phpunit": {
+							"title": "PHPUnit configuration parameters",
+							"type": "object"
+						}
+					}
+				}
+			}
+		}
+	},
+	"allOf": [
+		{
+			"type": "object",
+			"properties": {
+				"extra": {
+					"type": "object",
+					"properties": {
+						"altis": {
+							"type": "object",
+							"description": "Altis configuration",
+							"properties": {
+								"modules": {
+									"$ref": "#/definitions/altis-modules"
+								},
+								"environments": {
+									"description": "Configuration for local and Altis Cloud environments",
+									"type": "object",
+									"properties": {
+										"local": {
+											"description": "Local server environment",
+											"properties": {
+												"modules": {
+													"$ref": "#/definitions/altis-modules"
+												}
+											}
+										},
+										"ci": {
+											"description": "CI environment",
+											"properties": {
+												"modules": {
+													"$ref": "#/definitions/altis-modules"
+												}
+											}
+										},
+										"development": {
+											"description": "Development server cloud environment",
+											"properties": {
+												"modules": {
+													"$ref": "#/definitions/altis-modules"
+												}
+											}
+										},
+										"staging": {
+											"description": "Staging server cloud environment",
+											"properties": {
+												"modules": {
+													"$ref": "#/definitions/altis-modules"
+												}
+											}
+										},
+										"production": {
+											"description": "Production server cloud environment",
+											"properties": {
+												"modules": {
+													"$ref": "#/definitions/altis-modules"
+												}
+											}
+										}
+									},
+									"additionalProperties": false
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		{
+			"$ref": "https://getcomposer.org/schema.json"
+		}
+	]
+}


### PR DESCRIPTION
It's possible to use `allOf` in JSON Schema to combine the constraints from multiple schemas into one. This means we can create a schema for composer.json which is a combination of [the official Composer schema](https://getcomposer.org/schema.json) with our own schema for the `extra.altis` properties.

Adding `"$schema": "vendor/altis/core/schema.json",` to the top of an application-level composer.json file means VS Code provides all the JSON schema goodness you'd expect for a complete schema, including autocomplete, hover documentation with links, and validation.

By using a root `definitions` we also allow all the module definitions to appear in `extra.altis.modules` as well as each environment within `extra.altis.environments` without duplicating everything five times.

## Screenshots

Top level modules:

<img width="516" alt="" src="https://user-images.githubusercontent.com/208434/233417325-9db03c67-17e6-45e4-8dc7-bb0be46b0f0f.png">

Environment modules:

<img width="529" alt="" src="https://user-images.githubusercontent.com/208434/233418338-2d42fc64-cafb-4d29-b853-e73bb43179f7.png">

Autocomplete

<img width="574" alt="" src="https://user-images.githubusercontent.com/208434/233418891-d6575bd8-e8d8-421c-80dd-37dbb61cf2b9.png">

## Status

This is a proof of concept. There is a maintenance overhead for such a schema so we could make more use of `$ref` in order to pull in each module definition from its place in the vendor directory if that's preferable.

Thoughts?