### PR TITLE
Add custom configuration for Action Scheduler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		"files": [
 			"inc/namespace.php",
 			"inc/about/namespace.php",
+			"inc/compatibility/namespace.php",
 			"inc/global_content/namespace.php",
 			"inc/upgrades/namespace.php",
 			"inc/telemetry/namespace.php"

--- a/inc/compatibility/namespace.php
+++ b/inc/compatibility/namespace.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Altis\Compatibility;
+
+/**
+ * Bootstrap compatibility tweaks.
+ */
+function bootstrap() {
+	add_action( 'plugins_loaded', __NAMESPACE__ . '\\set_woocommerce_compatibility' );
+}
+
+/**
+ * Set hooks for WooCommerce compatibility and optimization.
+ *
+ * Adjusts Action Scheduler to run optimially with Cavalcade, by avoiding
+ * fallbacks and maximising the Cavalcade queue.
+ *
+ * The time limit and batch size hooks are set at priority 0 to allow sites to
+ * easily override for their specific use case.
+ */
+function set_woocommerce_compatibility() {
+	if ( class_exists( '\\ActionScheduler' ) ) {
+		return;
+	}
+
+	// Disable Action Scheduler's async request fallback to ensure it runs
+	// via Cavalcade.
+	add_filter( 'action_scheduler_allow_async_request_runner', '__return_false', 1000 );
+
+	// Allow Action Scheduler to run for 5 minutes (Cavalcade's limit is 60,
+	// but most hosts stay around 1-2 minutes)
+	add_filter( 'action_scheduler_queue_runner_time_limit', function () {
+		return 5 * MINUTE_IN_SECONDS;
+	}, 0 );
+
+	// Increase queue batch size from 25 to 250: we give 12x the default time
+	// (5 minutes instead of 30s), so should be able to run 8x the number of jobs comfortably.
+	add_filter( 'action_scheduler_queue_runner_batch_size', function () {
+		return 250;
+	}, 0 );
+}

--- a/inc/compatibility/namespace.php
+++ b/inc/compatibility/namespace.php
@@ -19,7 +19,7 @@ function bootstrap() {
  * easily override for their specific use case.
  */
 function set_woocommerce_compatibility() {
-	if ( class_exists( '\\ActionScheduler' ) ) {
+	if ( ! class_exists( '\\ActionScheduler' ) ) {
 		return;
 	}
 

--- a/inc/compatibility/namespace.php
+++ b/inc/compatibility/namespace.php
@@ -22,6 +22,15 @@ function bootstrap() {
  *
  * The time limit and batch size hooks are set at priority 0 to allow sites to
  * easily override for their specific use case.
+ *
+ * We disable the async task runner entirely, to avoid the loopback HTTP
+ * requests to admin-ajax.php. This triggers when AS detects cron not working,
+ * but doesn't account for the Cavalcade backlog and scaling system, and
+ * triggers too eagerly. Instead, we prefer a slight delay as Cavalcade scales
+ * up, avoiding the loopbacks.
+ *
+ * The limits are adjusted to account for the better processing power and
+ * limits of Cavalcade.
  */
 function set_woocommerce_compatibility() {
 	if ( ! class_exists( '\\ActionScheduler' ) ) {

--- a/inc/compatibility/namespace.php
+++ b/inc/compatibility/namespace.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Compatibility tweaks for optimal performance.
+ *
+ * @package altis/core
+ */
 
 namespace Altis\Compatibility;
 
@@ -28,7 +33,7 @@ function set_woocommerce_compatibility() {
 	add_filter( 'action_scheduler_allow_async_request_runner', '__return_false', 1000 );
 
 	// Allow Action Scheduler to run for 5 minutes (Cavalcade's limit is 60,
-	// but most hosts stay around 1-2 minutes)
+	// but most hosts stay around 1-2 minutes).
 	add_filter( 'action_scheduler_queue_runner_time_limit', function () {
 		return 5 * MINUTE_IN_SECONDS;
 	}, 0 );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -17,6 +17,7 @@ const API_NAMESPACE = 'altis/v1';
  */
 function bootstrap() {
 	About\bootstrap();
+	Compatibility\bootstrap();
 	Upgrades\bootstrap();
 	Telemetry\bootstrap();
 


### PR DESCRIPTION
Optimises Action Scheduler to always use Cavalcade, instead of falling back to async requests. In addition, tweaks some numbers to ensure queues are processed efficiently.

Fixes #780

See also, https://github.com/woocommerce/action-scheduler/blob/trunk/docs/perf.md

@joehoyle to tweak and test these numbers further.