### PR TITLE
Remove hard-coded installation path for hm-gtm

### DIFF
--- a/inc/composer/class-override-installer.php
+++ b/inc/composer/class-override-installer.php
@@ -71,7 +71,6 @@ class Override_Installer extends BaseInstaller {
 			'humanmade/cavalcade',
 			'humanmade/debug-bar-elasticpress',
 			'humanmade/delegated-oauth',
-			'humanmade/hm-gtm',
 			'humanmade/hm-redirects',
 			'humanmade/hm-limit-login-attempts',
 			'humanmade/ludicrousdb',


### PR DESCRIPTION
This removes the hard-coded installation path for the `humanmade/hm-gtm` package. If on v17 you manually install `hm-gtm` without `altis/analytics`, it should end up in `content/plugins` not in `vendor`.
Fixes https://github.com/humanmade/altis-documentation/issues/552