### PR TITLE
Reformat docs files after linting

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,9 @@
 # Core
 
-![](./assets/banner-core.png)
+![Core banner](./assets/banner-core.png)
 
-The core module provides the entry point for platform code. It includes functionality for retrieving information about the current environment, the module registry, plus parsing and reading the project configuration.
+The core module provides the entry point for platform code. It includes functionality for retrieving information about the current
+environment, the module registry, plus parsing and reading the project configuration.
 
 **Note:** all functions documented below are under the `Altis` namespace.
 
@@ -16,72 +17,81 @@ Returns the current hosting stack name based on the `HM_ENV` constant. On local 
 
 **`get_environment_type() : string`**
 
-Returns one of `local`, `development`, `staging` or `production`. This is read from the `HM_ENV_TYPE` constant except on local setups.
+Returns one of `local`, `development`, `staging` or `production`. This is read from the `HM_ENV_TYPE` constant except on local
+setups.
 
 **`get_environment_region() : ?string`**
 
-Returns the current AWS application's region based on the `HM_ENV_REGION` constant. On local setups or if the region is not set this will return `null`. The region can be `us-east-1`, `ap-northeast-1`, `eu-central-1` etc.
+Returns the current AWS application's region based on the `HM_ENV_REGION` constant. On local setups or if the region is not set this
+will return `null`. The region can be `us-east-1`, `ap-northeast-1`, `eu-central-1` etc.
 
 **`get_environment_architecture() : string`**
 
-Returns the current server architecture, currently this is one of `ecs` or `ec2`. `ec2` is the legacy architecture while `ecs` is the new container based system.
+Returns the current server architecture, currently this is one of `ecs` or `ec2`. `ec2` is the legacy architecture while `ecs` is
+the new container based system.
 
 **`get_environment_codebase_revision() : string`**
 
-Returns the current revision of the codebase deployed to the current environment. This will be the GIT commit hash of the latest commit that was deployed in the most recent deploy.
+Returns the current revision of the codebase deployed to the current environment. This will be the GIT commit hash of the latest
+commit that was deployed in the most recent deploy.
 
 ## AWS SDK
 
-The AWS SDK is always available and preconfigured with the necessary credentials on all non local servers. Access to additional APIs can be requested if needed.
+The AWS SDK is always available and preconfigured with the necessary credentials on all non local servers. Access to additional APIs
+can be requested if needed.
 
 **`get_aws_sdk() : Aws\Sdk`**
 
 Returns an instance of the base AWS SDK with preconfigured credentials.
 
-The credentials can be supplied by providing the `modules.core.aws` setting in the configuration. It's recommended that this be done only for the local environment:
+The credentials can be supplied by providing the `modules.core.aws` setting in the configuration. It's recommended that this be done
+only for the local environment:
 
-```
+```json
 {
-	"extra": {
-		"altis": {
-			"environments":{
-				"local": {
-					"modules": {
-						"core" : {
-							"aws":{
-								"region": "us-east-1",
-								"key": "xxxxxxxxxxxxxxxxxxxx",
-								"secret": "xxxxxxxxxxxxxxxxxxxxxxxxxx"
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "environments": {
+                "local": {
+                    "modules": {
+                        "core": {
+                            "aws": {
+                                "region": "us-east-1",
+                                "key": "xxxxxxxxxxxxxxxxxxxx",
+                                "secret": "xxxxxxxxxxxxxxxxxxxxxxxxxx"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 ```
 
-The AWS SDK can be also configured in code by using `altis.aws_sdk.params` filter which is called right before the global instance of the AWS SDK is created.
+The AWS SDK can be also configured in code by using `altis.aws_sdk.params` filter which is called right before the global instance
+of the AWS SDK is created.
 
-**Note:** this filter can only be used in the bootstrap function of an Altis module as it's called very early in the loading process.
+**Note:** this filter can only be used in the bootstrap function of an Altis module as it's called early in the loading process.
 
 ```php
 add_filter( 'altis.aws_sdk.params', 'aws_sdk_params' );
 
 function aws_sdk_params( array $params ) : array {
-	$params['region'] = 'new_region';
-	return $params;
+    $params['region'] = 'new_region';
+    return $params;
 }
 ```
 
 ## Autoloader
 
-For convenience, an autoloader which follows the WordPress class file naming standard is available. This can be used in code following the WordPress file naming standards; if using PSR-based standards, we recommend using the Composer autoloaders instead.
+For convenience, an autoloader which follows the WordPress class file naming standard is available. This can be used in code
+following the WordPress file naming standards; if using PSR-based standards, we recommend using the Composer autoloaders instead.
 
 **`register_class_path( string $prefix, string $path ) : void`**
 
-Registers the given prefix to be autoloaded from the given path. The prefix can either be a legacy-style class prefix (e.g. `Altis_CMS_`) or a namespace (e.g. `Altis\CMS`).
+Registers the given prefix to be autoloaded from the given path. The prefix can either be a legacy-style class prefix (
+e.g. `Altis_CMS_`) or a namespace (e.g. `Altis\CMS`).
 
 Classes are mapped to paths through the following process:
 
@@ -91,22 +101,25 @@ Classes are mapped to paths through the following process:
 4. Underscores in the class name (but not the parent namespace) are converted to dashes
 5. The name is prefixed with `class-`
 
-For example, with `register_class_path( 'Altis\CMS', '/dir' )`, the class `Altis\CMS\Alpha_Beta\Gamma_Delta` would be expected to live at `/dir/alpha_beta/class-gamma-delta.php`.
-
+For example, with `register_class_path( 'Altis\CMS', '/dir' )`, the class `Altis\CMS\Alpha_Beta\Gamma_Delta` would be expected to
+live at `/dir/alpha_beta/class-gamma-delta.php`.
 
 ## Configuration
 
-The configuration for the project determines which modules are loaded and how they behave. It can also be used for arbitrary project configuration.
+The configuration for the project determines which modules are loaded and how they behave. It can also be used for arbitrary project
+configuration.
 
 ### Functions
 
 **`get_config() : array`**
 
-Returns the complete configuration for the project including modules and their defaults and any overrides from the root `composer.json` configuration.
+Returns the complete configuration for the project including modules and their defaults and any overrides from the
+root `composer.json` configuration.
 
 ### Filters
 
-These filters are intended for use by autoloaded files in modules and must be hooked into early. They provide a means of adding additional configuration features such as per environment overrides and configuration post-processing.
+These filters are intended for use by autoloaded files in modules and must be hooked into early. They provide a means of adding
+additional configuration features such as per environment overrides and configuration post-processing.
 
 **`altis.config.default : array $default_config`**
 
@@ -130,7 +143,8 @@ Note that the modules interface is intended for internal use only and is documen
 
 **`register_module( string $slug, string $directory, string $title, ?array $default_settings, ?callable $loader ) : Module`**
 
-Registers and returns a `Module` object. If the module setting `enabled` is true the loader callback will be run on the `altis.modules.<slug>.loaded` action hook.
+Registers and returns a `Module` object. If the module setting `enabled` is true the loader callback will be run on
+the `altis.modules.<slug>.loaded` action hook.
 
 This function must be called on the `altis.modules.init` action hook.
 
@@ -146,4 +160,7 @@ Fired after the autoloader has been included. Modules can only be registered on 
 
 **`altis.modules.<slug>.loaded : Module $module`**
 
-Used to fire a module's registered loader callback. Receives the `Module` object registered with the corresponding slug as an argument.
+Used to fire a module's registered loader callback. Receives the `Module` object registered with the corresponding slug as an
+argument.
+
+<!-- markdownlint-disable-file MD024 -->

--- a/docs/cli-command.md
+++ b/docs/cli-command.md
@@ -13,12 +13,15 @@ The migration command runs all basic maintenance tasks required after upgrading 
 There are 2 ways to hook into this command:
 
 1. Using the `altis.migrate` action hook:
+
    ```php
    add_action( 'altis.migrate', function ( array $args, array $assoc_args ) {
        // Run upgrade routines here.
    } );
    ```
+
 2. Using WP CLI hooks:
+
    ```php
    WP_CLI::add_hook( 'after_invoke:altis migrate', function () {
        // Run migration routines here.

--- a/docs/custom-modules.md
+++ b/docs/custom-modules.md
@@ -1,10 +1,12 @@
 ---
 order: 30
 ---
+
 # Custom Modules
 
-Altis is designed in a modular way, allowing your project to turn on and off individual modules as appropriate. You can use this same infrastructure for your own custom modules, allowing you to take advantage of frameworks such as the configuration and documentation modules.
-
+Altis is designed in a modular way, allowing your project to turn on and off individual modules as appropriate. You can use this
+same infrastructure for your own custom modules, allowing you to take advantage of frameworks such as the configuration and
+documentation modules.
 
 ## Location
 
@@ -15,44 +17,53 @@ Custom modules can be created in one of two ways:
 
 We recommend developing modules following the project-specific guide first, then converting to reusable modules later.
 
-
 ## Project-Specific Modules
 
-To start a new project-specific module to your project, first create a directory for the module to live in. We recommend using `content/mu-plugins/{your-module-name}`, to match the commonly-used [WordPress must-use plugins](https://codex.wordpress.org/Must_Use_Plugins) pattern.
+To start a new project-specific module to your project, first create a directory for the module to live in. We recommend
+using `content/mu-plugins/{your-module-name}`, to match the
+commonly-used [WordPress must-use plugins](https://codex.wordpress.org/Must_Use_Plugins) pattern.
 
-Your module's file structure can be structured however you like, but we recommend following the [Human Made plugin structure](https://engineering.hmn.md/standards/structure/#plugin-structure). This structure ensures your code remains maintainable.
+Your module's file structure can be structured however you like, but we recommend following
+the [Human Made plugin structure](https://engineering.hmn.md/standards/structure/#plugin-structure). This structure ensures your
+code remains maintainable.
 
-There are two basic parts required to creating a module: load your module's file in using the Composer autoloader, and register your module with the Altis core. We recommend having a main entrypoint file (conventionally called `load.php`) which handles loading and registering your module, with other code split into functions and classes in separate files (conventionally within an `inc` directory).
-
+There are two basic parts required to creating a module: load your module's file in using the Composer autoloader, and register your
+module with the Altis core. We recommend having a main entrypoint file (conventionally called `load.php`) which handles loading and
+registering your module, with other code split into functions and classes in separate files (conventionally within an `inc`
+directory).
 
 ### Loading Your Module
 
-In order to use your module, the module needs to be loaded in by the Composer autoloader. This allows the module to register itself with the Altis core, as well as load in any functions or classes it needs.
+In order to use your module, the module needs to be loaded in by the Composer autoloader. This allows the module to register itself
+with the Altis core, as well as load in any functions or classes it needs.
 
-To load in your module's entrypoint file, add it to the module's configuration in your project's `composer.json`. For example, for a module called `custom-module` placed in the `mu-plugins` directory and with an entrypoint file called `load.php`, your `composer.json` should contain the following:
+To load in your module's entrypoint file, add it to the module's configuration in your project's `composer.json`. For example, for a
+module called `custom-module` placed in the `mu-plugins` directory and with an entrypoint file called `load.php`,
+your `composer.json` should contain the following:
 
 ```json
 {
-  "extra": {
-    "altis": {
-      "modules": {
-        "custom-module": {
-          "entrypoint": [
-            "content/mu-plugins/custom-module/load.php"
-          ]
+    "extra": {
+        "altis": {
+            "modules": {
+                "custom-module": {
+                    "entrypoint": [
+                        "content/mu-plugins/custom-module/load.php"
+                    ]
+                }
+            }
         }
-      }
     }
-  }
 }
 ```
 
 After adding this, run `composer dump-autoload` to regenerate the autoload files for your project.
 
-
 ### Registering Your Module
 
-Within your module's entrypoint file, your module needs to register itself with the Altis core. To do this, you need to add an action on `altis.modules.init` which calls `Altis\register_module()`. This function call registers the module as well as any default configuration and a callback for the module.
+Within your module's entrypoint file, your module needs to register itself with the Altis core. To do this, you need to add an
+action on `altis.modules.init` which calls `Altis\register_module()`. This function call registers the module as well as any default
+configuration and a callback for the module.
 
 A basic registration call looks like:
 
@@ -60,33 +71,34 @@ A basic registration call looks like:
 use function Altis\register_module;
 
 add_action( 'altis.modules.init', function () {
-	register_module(
-		// Module ID:
-		'your-module',
+    register_module(
+        // Module ID:
+        'your-module',
 
-		// Module directory:
-		__DIR__,
+        // Module directory:
+        __DIR__,
 
-		// Human-readable name:
-		'Your Module',
+        // Human-readable name:
+        'Your Module',
 
-		// Module options, as an array:
-		[
-			// Defaults define the default settings for the module.
-			'defaults' => [
-				// `enabled` is a special configuration key, which sets whether the module is
-				// enabled by default or not. Defaults to "false".
-				'enabled' => true,
-			],
-		],
+        // Module options, as an array:
+        [
+            // Defaults define the default settings for the module.
+            'defaults' => [
+                // `enabled` is a special configuration key, which sets whether the module is
+                // enabled by default or not. Defaults to "false".
+                'enabled' => true,
+            ],
+        ],
 
-		// Function to call if the module is enabled.
-		__NAMESPACE__ . '\\bootstrap'
-	);
+        // Function to call if the module is enabled.
+        __NAMESPACE__ . '\\bootstrap'
+    );
 } );
 ```
 
-Your entrypoint file can declare constants or load in other files as necessary to load functions and classes. A typical entrypoint file looks like:
+Your entrypoint file can declare constants or load in other files as necessary to load functions and classes. A typical entrypoint
+file looks like:
 
 ```php
 <?php
@@ -101,37 +113,44 @@ const DIRECTORY = __DIR__;
 require_once __DIR__ . '/inc/namespace.php';
 
 add_action( 'altis.modules.init', function () {
-	register_module(
-		'your-module',
-		DIRECTORY,
-		'Your Module',
-		[
-			'defaults' => [
-				'enabled' => true,
-			],
-		],
-		__NAMESPACE__ . '\\bootstrap'
-	);
+    register_module(
+        'your-module',
+        DIRECTORY,
+        'Your Module',
+        [
+            'defaults' => [
+                'enabled' => true,
+            ],
+        ],
+        __NAMESPACE__ . '\\bootstrap'
+    );
 } );
 ```
 
-
 ### Module Settings
 
-When registering your module, you pass various parameters to `register_module()`. These are used to control the behavior of your module.
+When registering your module, you pass various parameters to `register_module()`. These are used to control the behavior of your
+module.
 
-Your module's directory is used for automated loading and parsing of documentation. The Documentation module automatically looks for a `docs` subdirectory within this directory and parses Markdown files from this.
+Your module's directory is used for automated loading and parsing of documentation. The Documentation module automatically looks for
+a `docs` subdirectory within this directory and parses Markdown files from this.
 
-The default configuration passed in integrates with the [configuration system](configuration.md), and can be used to configure your module on different environments, or to provide an easy way to enable and disable specific functionality. Within your module, you can use `Altis\get_config()` to retrieve the resolved configuration; your module configuration can be accessed as `get_config()[ $id ]`, where `$id` is the same ID you pass to the module registration.
-
+The default configuration passed in integrates with the [configuration system](configuration.md), and can be used to configure your
+module on different environments, or to provide an easy way to enable and disable specific functionality. Within your module, you
+can use `Altis\get_config()` to retrieve the resolved configuration; your module configuration can be accessed
+as `get_config()[ $id ]`, where `$id` is the same ID you pass to the module registration.
 
 ## Reusable Modules
 
-For reusable modules, follow the project-specific module development process above. Reusable modules are simply regular Composer packages, so you can follow existing guides on how to publish Composer packages, or follow the Altis-specific guide below.
+For reusable modules, follow the project-specific module development process above. Reusable modules are simply regular Composer
+packages, so you can follow existing guides on how to publish Composer packages, or follow the Altis-specific guide below.
 
-Once you're ready to convert your module into a reusable module, the first step is to split your module's code into a separate repository. Composer requires separate packages to be published from separate repositories.
+Once you're ready to convert your module into a reusable module, the first step is to split your module's code into a separate
+repository. Composer requires separate packages to be published from separate repositories.
 
-In your new repository, your module needs a `composer.json` to specify dependencies, the package's name, and autoloading code. Your package should declare a dependency on the core Altis package, fixed to the major Altis version you are working with. The autoloader specification should be migrated from your project's `composer.json` to the module's.
+In your new repository, your module needs a `composer.json` to specify dependencies, the package's name, and autoloading code. Your
+package should declare a dependency on the core Altis package, fixed to the major Altis version you are working with. The autoloader
+specification should be migrated from your project's `composer.json` to the module's.
 
 The entrypoint file _must_ be called `load.php` in a reusable module.
 
@@ -139,28 +158,31 @@ A basic `composer.json` could look like:
 
 ```json
 {
-  "name": "company-name/your-project",
-  "autoload": {
-    "files": [
-      "inc/namespace.php"
-    ],
-    "classmap": [
-      "inc/",
-    ]
-  },
-  "require": {
-    "altis/core": "~1.0"
-  },
-  "extra": {
-    "altis": {}
-  }
+    "name": "company-name/your-project",
+    "autoload": {
+        "files": [
+            "inc/namespace.php"
+        ],
+        "classmap": [
+            "inc/"
+        ]
+    },
+    "require": {
+        "altis/core": "~1.0"
+    },
+    "extra": {
+        "altis": {}
+    }
 }
 ```
 
-The crucial portion is the `extra.altis` property. This will ensure the module's `load.php` file that contains the module registration code will only be run in the appropriate context.
+The crucial portion is the `extra.altis` property. This will ensure the module's `load.php` file that contains the module
+registration code will only be run in the appropriate context.
 
-For open-source packages, you should then publish this package to [Packagist](https://packagist.org/).
+For open-source packages, you should then publish this package to [Packagist, the PHP package repository](https://packagist.org/).
 
-For private packages you don't want to publish publically, you can use Private Packagist or Satis; we recommend following the [Composer private packages guide](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md).
+For private packages, you can use [Private Packagist](https://packagist.com/) or [Satis](https://composer.github.io/satis/); we
+recommend following
+the [Composer private packages guide](https://getcomposer.org/doc/articles/handling-private-packages-with-satis.md).
 
 Once published, this can then be added to your project's `composer.json` file via the `composer require` command.

--- a/docs/global-content-repository.md
+++ b/docs/global-content-repository.md
@@ -1,20 +1,28 @@
 # Global Content Repository
 
-Altis includes a Global Content Repository framework. This is a site on the network that can be used to distribute content elsewhere via the REST API or directly to other sites on the network.
+Altis includes a Global Content Repository framework. This is a site on the network that can be used to distribute content elsewhere
+via the REST API or directly to other sites on the network.
 
-By default the Global Content Repository only exposes the user management admin. Other Altis modules may extend this, for example [the Altis Media module has a Global Media Library feature](docs://media/global-media-library.md) built on top of the Global Content Repository that allows for uploading media files and accessing them from all sites on the network.
+By default, the Global Content Repository only exposes the user management admin. Other Altis modules may extend this, for
+example [the Altis Media module has a Global Media Library feature](docs://media/global-media-library.md) built on top of the Global
+Content Repository that allows for uploading media files and accessing them from all sites on the network.
 
-The Global Content Repository site is set to be a private site by default. This can be modified by switching the site to a public one from the Network Admin > Sites management page, clicking `Edit` on the site, and checking the `Public` checkbox.
+The Global Content Repository site is set to be a private site by default. This can be modified by switching the site to a public
+one from the Network Admin > Sites management page, clicking `Edit` on the site, and checking the `Public` checkbox.
 
-**Note:** When using media from the Global Content Repository, the URL for the selected media will always be relative to that of your Global Content Repository site and not the site it's being displayed on.
+**Note:** When using media from the Global Content Repository, the URL for the selected media will always be relative to that of
+your Global Content Repository site and not the site it's being displayed on.
 
 ## User Management
 
-Users on the multisite network can have different roles on different sites. This gives you control over who can add and edit global content versus who can only use the global content on their own site.
+Users on the multisite network can have different roles on different sites. This gives you control over who can add and edit global
+content versus who can only use the global content on their own site.
 
-You might have a user who is an author on the main site, but have no role on the Global Content Repository meaning they could read content to use in their posts but not create or edit global content nor access the global site admin.
+You might have a user who is an author on the main site, but have no role on the Global Content Repository meaning they could read
+content to use in their posts but not create or edit global content nor access the global site admin.
 
-Conversely you may have a user who does not have a role on your primary site but who can create and edit content on the Global Content Repository site.
+Conversely you may have a user who does not have a role on your primary site but who can create and edit content on the Global
+Content Repository site.
 
 ## Functions
 
@@ -56,7 +64,8 @@ add_filter( 'altis.core.global_content_site_menu_pages', function ( array $args 
 
 **`altis.core.global_content_site_menu_pages : array $pages`**
 
-Filters the allowed top level admin menu pages. Defaults to `[ 'users.php' ]`. To add support for pages you could use the following code:
+Filters the allowed top level admin menu pages. Defaults to `[ 'users.php' ]`. To add support for pages you could use the following
+code:
 
 ```php
 add_filter( 'altis.core.global_content_site_menu_pages', function ( array $pages ) : array {


### PR DESCRIPTION
This changes all the docs files to be formatted correctly after linting. The main changes are line length, spaces instead of tabs, and addition of alt text for images. Some grammar and spelling issues were also fixed.

Resolves https://github.com/humanmade/altis-core/issues/630