### PR TITLE
Re-pinning this AWS SDK PHP to 3.351.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=8.2",
-		"aws/aws-sdk-php": "3.356.17",
+		"aws/aws-sdk-php": "3.351.7",
 		"composer-plugin-api": "^1.1 || ^2.0",
 		"composer/installers": "^1.12 || ^2.3.0",
 		"segmentio/analytics-php": "~3.8.1"


### PR DESCRIPTION
Something in the AWS SDK for PHP 3.351.8 is causing local uploads to fail. They still work on 3.351.7, so we are pinning the version to that until we can figure out what we need to do to accommodate the changes.

Resolves humanmade/product-dev#1831