### PR TITLE
Add `wp altis post-sync` CLI command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 			"inc/compatibility/namespace.php",
 			"inc/global_content/namespace.php",
 			"inc/upgrades/namespace.php",
-			"inc/telemetry/namespace.php"
+			"inc/telemetry/namespace.php",
+			"inc/post_sync/namespace.php"
 		],
 		"classmap": [
 			"inc/"

--- a/docs/cli-command.md
+++ b/docs/cli-command.md
@@ -41,8 +41,9 @@ WP_CLI::add_hook( 'after_invoke:altis migrate', function () {
 The post-sync command runs routine maintenance tasks after syncing an environment, for example after pulling a production 
 database to staging or development. By default, this includes:
 
-- Reindexing Elasticsearch (if available)
 - Truncating the Cavalcade cron logs table
+- Reindexing Elasticsearch when the Search module is enabled (see
+  [Search module docs](docs://search/cli-command.md))
 
 ### Hooking into the command
 
@@ -69,12 +70,12 @@ There are 2 ways to hook into this command:
 All default tasks are registered as named functions, so they can be unhooked individually:
 
 ```php
-// Skip the Elasticsearch reindex.
-remove_action( 'altis.post_sync', 'Altis\Post_Sync\reindex_elasticsearch' );
-
 // Skip truncating Cavalcade logs.
 remove_action( 'altis.post_sync', 'Altis\Post_Sync\truncate_cavalcade_logs' );
 ```
+
+Tasks contributed by other modules (for example the Search module's Elasticsearch reindex) are documented
+alongside those modules.
 
 ### Customer examples
 

--- a/docs/cli-command.md
+++ b/docs/cli-command.md
@@ -41,7 +41,6 @@ WP_CLI::add_hook( 'after_invoke:altis migrate', function () {
 The post-sync command runs routine maintenance tasks after syncing an environment, for example after pulling a production 
 database to staging or development. By default, this includes:
 
-- Flushing the object cache
 - Reindexing Elasticsearch (if available)
 - Truncating the Cavalcade cron logs table
 
@@ -72,9 +71,6 @@ All default tasks are registered as named functions, so they can be unhooked ind
 ```php
 // Skip the Elasticsearch reindex.
 remove_action( 'altis.post_sync', 'Altis\Post_Sync\reindex_elasticsearch' );
-
-// Skip flushing the object cache.
-remove_action( 'altis.post_sync', 'Altis\Post_Sync\flush_object_cache' );
 
 // Skip truncating Cavalcade logs.
 remove_action( 'altis.post_sync', 'Altis\Post_Sync\truncate_cavalcade_logs' );

--- a/docs/cli-command.md
+++ b/docs/cli-command.md
@@ -35,3 +35,77 @@ WP_CLI::add_hook( 'after_invoke:altis migrate', function () {
     WP_CLI::runcommand( 'cli info' );
 } );
 ```
+
+## `wp altis post-sync`
+
+The post-sync command runs routine maintenance tasks after syncing an environment, for example after pulling a production 
+database to staging or development. By default, this includes:
+
+- Flushing the object cache
+- Reindexing Elasticsearch (if available)
+- Truncating the Cavalcade cron logs table
+
+### Hooking into the command
+
+There are 2 ways to hook into this command:
+
+1. Using the `altis.post_sync` action hook:
+
+   ```php
+   add_action( 'altis.post_sync', function () {
+       // Run post-sync routines here.
+   } );
+   ```
+
+2. Using WP CLI hooks:
+
+   ```php
+   WP_CLI::add_hook( 'after_invoke:altis post-sync', function () {
+       // Run post-sync routines here.
+   } );
+   ```
+
+### Removing default tasks
+
+All default tasks are registered as named functions, so they can be unhooked individually:
+
+```php
+// Skip the Elasticsearch reindex.
+remove_action( 'altis.post_sync', 'Altis\Post_Sync\reindex_elasticsearch' );
+
+// Skip flushing the object cache.
+remove_action( 'altis.post_sync', 'Altis\Post_Sync\flush_object_cache' );
+
+// Skip truncating Cavalcade logs.
+remove_action( 'altis.post_sync', 'Altis\Post_Sync\truncate_cavalcade_logs' );
+```
+
+### Customer examples
+
+Here are some common tasks you might want to run after syncing an environment:
+
+```php
+add_action( 'altis.post_sync', 'myproject_post_sync_tasks' );
+
+function myproject_post_sync_tasks() {
+    // Anonymize user data on non-production environments.
+    global $wpdb;
+    $wpdb->query(
+        "UPDATE {$wpdb->users} SET user_email = CONCAT( 'user', ID, '@example.com' ), user_pass = '' WHERE ID > 1"
+    );
+    WP_CLI::success( 'User data anonymized.' );
+
+    // Truncate a large logging table to reduce database size.
+    $wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}activity_log" );
+    WP_CLI::success( 'Activity log truncated.' );
+
+    // Disable analytics tracking on non-production environments.
+    update_option( 'analytics_enabled', false );
+    WP_CLI::success( 'Analytics disabled.' );
+
+    // Disable outbound API integrations.
+    update_option( 'crm_sync_enabled', false );
+    update_option( 'email_service_live', false );
+    WP_CLI::success( 'External API integrations disabled.' );
+}
+```

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -44,8 +44,7 @@ class Command extends WP_CLI_Command {
 	 * Run post-sync tasks.
 	 *
 	 * This command runs routine synchronization and maintenance tasks such as
-	 * flushing the object cache, reindexing Elasticsearch, and truncating
-	 * Cavalcade logs. It is intended to be run after syncing an environment,
+	 * reindexing Elasticsearch and truncating Cavalcade logs. It is intended to be run after syncing an environment,
 	 * for example pulling a production database to staging.
 	 *
 	 * Custom code can hook into this command using the `altis.post_sync` hook.

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -44,7 +44,8 @@ class Command extends WP_CLI_Command {
 	 * Run post-sync tasks.
 	 *
 	 * This command runs routine synchronization and maintenance tasks such as
-	 * reindexing Elasticsearch and truncating Cavalcade logs. It is intended to be run after syncing an environment,
+	 * truncating Cavalcade logs. Other modules (for example Search) may hook in
+	 * additional tasks. It is intended to be run after syncing an environment,
 	 * for example pulling a production database to staging.
 	 *
 	 * Custom code can hook into this command using the `altis.post_sync` hook.

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -40,4 +40,43 @@ class Command extends WP_CLI_Command {
 		do_action( 'altis.migrate', $args, $assoc_args );
 	}
 
+	/**
+	 * Run post-sync tasks.
+	 *
+	 * This command runs routine synchronization and maintenance tasks such as
+	 * flushing the object cache, reindexing Elasticsearch, and truncating
+	 * Cavalcade logs. It is intended to be run after syncing an environment,
+	 * for example pulling a production database to staging.
+	 *
+	 * Custom code can hook into this command using the `altis.post_sync` hook.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Run all post-sync tasks
+	 *     $ wp altis post-sync
+	 *
+	 *     # Run post-sync on a specific site
+	 *     $ wp altis post-sync --url=example.com
+	 *
+	 * @subcommand post-sync
+	 *
+	 * @param array $args Command arguments.
+	 * @param array $assoc_args Command associative arguments.
+	 */
+	public function post_sync( array $args, array $assoc_args ) {
+		WP_CLI::log( 'Running Altis post-sync tasks...' );
+
+		/**
+		 * Triggered by the `wp altis post-sync` command. Attach any custom
+		 * synchronization or maintenance tasks you need to run after syncing
+		 * an environment.
+		 *
+		 * @param array $args Any plain args passed to the command e.g. `wp altis post-sync myarg`.
+		 * @param array $assoc_args Any named arguments passed to the command e.g. `wp altis post-sync --url=example.org`.
+		 */
+		do_action( 'altis.post_sync', $args, $assoc_args );
+
+		WP_CLI::success( 'Post-sync tasks complete.' );
+	}
+
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -22,6 +22,7 @@ function bootstrap() {
 	Telemetry\bootstrap();
 
 	Global_Content\bootstrap();
+	Post_Sync\bootstrap();
 
 	// Register the Altis command.
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/inc/post_sync/namespace.php
+++ b/inc/post_sync/namespace.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Altis Post Sync actions.
+ *
+ * Default tasks run after syncing an environment, such as pulling
+ * a production database to staging or development.
+ *
+ * @package altis/core
+ */
+
+namespace Altis\Post_Sync;
+
+use WP_CLI;
+
+/**
+ * Bootstrap post-sync hooks.
+ *
+ * @return void
+ */
+function bootstrap() : void {
+	add_action( 'altis.post_sync', __NAMESPACE__ . '\\flush_object_cache' );
+	add_action( 'altis.post_sync', __NAMESPACE__ . '\\reindex_elasticsearch' );
+	add_action( 'altis.post_sync', __NAMESPACE__ . '\\truncate_cavalcade_logs' );
+}
+
+/**
+ * Flush the object cache.
+ *
+ * @return void
+ */
+function flush_object_cache() : void {
+	WP_CLI::log( 'Flushing object cache...' );
+	wp_cache_flush();
+	WP_CLI::success( 'Object cache flushed.' );
+}
+
+/**
+ * Reindex Elasticsearch if available.
+ *
+ * Skips reindexing if Elasticsearch is not configured for this environment.
+ *
+ * @return void
+ */
+function reindex_elasticsearch() : void {
+	if ( ! defined( 'ELASTICSEARCH_HOST' ) || ! ELASTICSEARCH_HOST ) {
+		WP_CLI::log( 'Elasticsearch not available, skipping reindex.' );
+		return;
+	}
+
+	WP_CLI::log( 'Reindexing Elasticsearch...' );
+	WP_CLI::runcommand( 'elasticpress sync --setup --network-wide --yes' );
+	WP_CLI::success( 'Elasticsearch reindex complete.' );
+}
+
+/**
+ * Truncate the Cavalcade logs table.
+ *
+ * Clears all cron job execution logs to reduce database size after sync.
+ *
+ * @return void
+ */
+function truncate_cavalcade_logs() : void {
+	global $wpdb;
+
+	$table = $wpdb->base_prefix . 'cavalcade_logs';
+
+	// Check the table exists before attempting to truncate.
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$table_exists = $wpdb->get_var(
+		$wpdb->prepare( 'SHOW TABLES LIKE %s', $table )
+	);
+
+	if ( ! $table_exists ) {
+		WP_CLI::log( 'Cavalcade logs table not found, skipping.' );
+		return;
+	}
+
+	WP_CLI::log( 'Truncating Cavalcade logs...' );
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+	$wpdb->query( "TRUNCATE TABLE `{$table}`" );
+	WP_CLI::success( 'Cavalcade logs truncated.' );
+}

--- a/inc/post_sync/namespace.php
+++ b/inc/post_sync/namespace.php
@@ -18,26 +18,7 @@ use WP_CLI;
  * @return void
  */
 function bootstrap() : void {
-	add_action( 'altis.post_sync', __NAMESPACE__ . '\\reindex_elasticsearch' );
 	add_action( 'altis.post_sync', __NAMESPACE__ . '\\truncate_cavalcade_logs' );
-}
-
-/**
- * Reindex Elasticsearch if available.
- *
- * Skips reindexing if Elasticsearch is not configured for this environment.
- *
- * @return void
- */
-function reindex_elasticsearch() : void {
-	if ( ! defined( 'ELASTICSEARCH_HOST' ) || ! ELASTICSEARCH_HOST ) {
-		WP_CLI::log( 'Elasticsearch not available, skipping reindex.' );
-		return;
-	}
-
-	WP_CLI::log( 'Reindexing Elasticsearch...' );
-	WP_CLI::runcommand( 'elasticpress sync --setup --network-wide --yes' );
-	WP_CLI::success( 'Elasticsearch reindex complete.' );
 }
 
 /**

--- a/inc/post_sync/namespace.php
+++ b/inc/post_sync/namespace.php
@@ -18,20 +18,8 @@ use WP_CLI;
  * @return void
  */
 function bootstrap() : void {
-	add_action( 'altis.post_sync', __NAMESPACE__ . '\\flush_object_cache' );
 	add_action( 'altis.post_sync', __NAMESPACE__ . '\\reindex_elasticsearch' );
 	add_action( 'altis.post_sync', __NAMESPACE__ . '\\truncate_cavalcade_logs' );
-}
-
-/**
- * Flush the object cache.
- *
- * @return void
- */
-function flush_object_cache() : void {
-	WP_CLI::log( 'Flushing object cache...' );
-	wp_cache_flush();
-	WP_CLI::success( 'Object cache flushed.' );
 }
 
 /**


### PR DESCRIPTION
## Summary

Introduces the `wp altis post-sync` CLI command and the `altis.post_sync` action hook. Custom code and other Altis modules can hook into this command to run maintenance tasks after an environment sync (for example, pulling a production database to staging or development).

This PR ships one default handler in core:

- **Truncate Cavalcade logs** — truncates the `cavalcade_logs` table (skips if the table is not found).

The handler is a named function (`Altis\Post_Sync\truncate_cavalcade_logs`) that customers can unhook individually via `remove_action()`.

Other modules contribute their own handlers in their own packages. In particular, the Elasticsearch reindex handler that previously lived here has moved to the Search module — see humanmade/altis-enhanced-search#573.

- Addresses #1298

## Test plan

- [ ] Run `wp altis post-sync` — completes successfully and the Cavalcade logs table is truncated.
- [ ] On a site without the `cavalcade_logs` table, verify the truncate step is skipped with a log message rather than erroring.
- [ ] Verify a custom action can be hooked: `add_action( 'altis.post_sync', function () { WP_CLI::log( 'Custom task ran' ); } );`.
- [ ] Verify the default action can be removed: `remove_action( 'altis.post_sync', 'Altis\\Post_Sync\\truncate_cavalcade_logs' );`.
- [ ] Check `wp help altis post-sync` shows the command documentation.
- [ ] With humanmade/altis-enhanced-search#573 merged/checked out locally, verify the Elasticsearch reindex still runs when `wp altis post-sync` is invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)