### PR TITLE
Fix startup race that leaves global content site options masked by stale cache

### DIFF
--- a/inc/global_content/namespace.php
+++ b/inc/global_content/namespace.php
@@ -171,6 +171,11 @@ function maybe_create_site() {
 	update_site_option( 'global_content_site_url', rtrim( $site_url, '/' ) );
 	update_site_option( 'global_content_site_id', $site_id );
 
+	// A stale `notoptions` cache entry — populated when other requests read these
+	// options before this function ran — can otherwise mask the values we just set,
+	// since get_network_option consults notoptions before the value cache.
+	wp_cache_delete( get_current_network_id() . ':notoptions', 'site-options' );
+
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		WP_CLI::success( 'Global Content Repository site created!' );
 	}


### PR DESCRIPTION
## Summary
Fixes a startup race condition where the global content repository site
is created correctly but `get_site_option('global_content_site_url')`
returns `false` indefinitely — so the media module's "Global Content
Repository site does not exist yet" warning fires on every request
until the object cache is manually flushed.

## Root cause
Requests that hit `get_site_option('global_content_site_url')` before
`maybe_create_site` has run populate the `notoptions` entry for the
`site-options` cache group, marking the option as non-existent. WP
core's `add_network_option` (reached via `update_site_option`) tries
to invalidate that entry, but its invalidation is guarded by a live
re-read of the cache — under install-time load (multiple processes,
Redis writes piling up), that re-read can miss and the invalidation
is silently skipped. Since `get_network_option` consults `notoptions`
*before* the value cache or DB, the options appear missing even though
they're set in `wp_sitemeta`.

## Fix
After the `update_site_option` calls in `maybe_create_site`,
unconditionally delete the `<network_id>:notoptions` key in the
`site-options` cache group. This guarantees the next read re-checks
the DB regardless of what happened upstream.

## Test plan
- [ ] Fresh stack spin-up with global-media-library enabled produces no
  "Global Content Repository site does not exist" warnings after
  `wp altis migrate` completes.
- [ ] Reproduction: wipe sitemeta rows + /repo/ blog, flush cache, hit
  the site several times via curl to pollute notoptions, then run
  `wp altis migrate` — `get_site_option('global_content_site_url')`
  returns the URL without needing a cache flush.