### PR TITLE
Populate install overrides on plugin activation

### DIFF
--- a/inc/composer/class-plugin.php
+++ b/inc/composer/class-plugin.php
@@ -53,6 +53,15 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 
 		$this->installer = new Override_Installer( $this->io, $this->composer );
 		$this->composer->getInstallationManager()->addInstaller( $this->installer );
+
+		// Populate overrides from the lock file immediately. Composer dispatches
+		// the `init` event by calling EventDispatcher::makeAutoloader() *before*
+		// invoking listeners — that builds a package map via getInstallPath() on
+		// every package, so if overrides are not set yet, every wordpress-plugin
+		// resolves to the root installer-paths template (content/plugins/{name}/)
+		// and ClassMapGenerator emits "Could not scan for classes inside ..."
+		// warnings against those non-existent paths.
+		$this->populate_overrides_from_lock();
 	}
 
 	/**
@@ -84,6 +93,15 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 
 		// If we have a lockfile set the overrides early to handle
 		// dump-autoload commands correctly.
+		$this->populate_overrides_from_lock();
+	}
+
+	/**
+	 * Populate install overrides on $this->installer from the lock file, if available.
+	 *
+	 * @return void
+	 */
+	protected function populate_overrides_from_lock() : void {
 		$lock_file = dirname( $this->composer->getConfig()->get( 'vendor-dir' ) ) . DIRECTORY_SEPARATOR . 'composer.lock';
 		if ( ! is_readable( $lock_file ) ) {
 			return;


### PR DESCRIPTION
## Summary

### TL;DR

Fixes these messages in composer 2.9+:
```
Could not scan for classes inside "content/plugins/query-monitor//classes" which does not appear to be a file nor a folder
Could not scan for classes inside "content/plugins/query-monitor//data" which does not appear to be a file nor a folder
Could not scan for classes inside "content/plugins/query-monitor//output" which does not appear to be a file nor a folder
Could not scan for classes inside "content/plugins/s3-uploads//inc/" which does not appear to be a file nor a folder
Could not scan for classes inside "content/plugins/amf-wordpress//inc" which does not appear to be a file nor a folder
```

---

- Composer's `EventDispatcher` calls `makeAutoloader()` *before* invoking `init` event listeners — that builds a package map by calling `getInstallPath()` on every package.
- Previously the activate-time `Override_Installer` had empty `installOverrides`, so every `wordpress-plugin` resolved to the root `installer-paths` template (`content/plugins/{name}/`) instead of its `vendor/` override.
- `ClassMapGenerator` then emitted `Could not scan for classes inside "content/plugins/<name>//<path>"` warnings against those non-existent paths on every composer command.
- The `init` listener was setting overrides correctly afterwards, but by then the warnings had already fired. The final classmap was correct (the second pass uses populated overrides), so this was noise rather than a functional break — but noisy.

This PR lifts the lock-file-based override population into a small helper and calls it from both `activate()` and `init()`, so the activate-time installer is already populated before the `init` event dispatch builds its package map.

## Test plan
- [ ] On a project that uses `install-overrides` (e.g. altis/local-development), run `composer dump-autoload` — verify no `Could not scan for classes inside ...` warnings appear.
- [ ] Run `composer install` from a clean state — verify overridden plugins still install into `vendor/<vendor>/<name>/` rather than `content/plugins/<name>/`.
- [ ] Run `composer install` against a project with no `composer.lock` yet — verify behaviour is unchanged (the helper short-circuits when no lock file is readable).