### PR TITLE
Re-pin aws/aws-sdk-php to 3.351.7 on v24-branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=8.2",
-		"aws/aws-sdk-php": "3.379.9",
+		"aws/aws-sdk-php": "3.351.7",
 		"composer-plugin-api": "^1.1 || ^2.0",
 		"composer/installers": "^1.12 || ^2.3.0",
 		"segmentio/analytics-php": "~3.8.2"


### PR DESCRIPTION
## Summary
- Roll `aws/aws-sdk-php` back from `3.379.9` to `3.351.7` on this branch.
- Re-aligns v24-branch with v23-branch, which has stayed pinned at 3.351.7 since #1293.
- Restores local S3 upload functionality that the dependabot bumps to 3.378.0+ regressed.

## Background
PR #1293 originally pinned us at 3.351.7 to fix local upload failures (humanmade/product-dev#1831) where the SDK produced SignatureDoesNotMatch errors against the local MinIO-backed S3. Dependabot subsequently bumped this branch via #1402 (3.378.0), #1408 (3.379.0), #1413 (3.379.5), and #1418 (3.379.9). Local testing confirms uploads regress on the bumped SDK versions; reverting to 3.351.7 restores them.

## Audit advisories
Pinning to 3.351.7 reintroduces two composer audit warnings:
- `PKSA-4t1p-xpk2-nsss` — CloudFront Policy Document Injection (`Aws\CloudFront\Signer`).
- `PKSA-dxyf-6n16-t87m` — S3 Encryption Client Key Commitment (`Aws\S3\Crypto\S3EncryptionClient*`).

Both cover features Altis does not use. Audit of `vendor/altis/`, `vendor/humanmade/`, and `packages/`:
- Zero call sites for `getSignedUrl`, `getSignedCookie`, `CloudFront\Signer`. Altis's only CloudFront use is `CloudFrontClient::createInvalidation` for cache purging (`packages/cloud/inc/namespace.php:1069`).
- Zero call sites for any `S3EncryptionClient*`, `InstructionFileMetadataStrategy`, or `MaterialsProvider`. `humanmade/s3-uploads` uses only the plain `S3Client`; there is no client-side encryption anywhere.

A companion PR on `altis/skeleton@v24-branch` adds matching `config.audit.ignore` entries to the project composer.json template so install succeeds on this pin.

## Test plan
- [ ] After the companion `altis/skeleton` PR lands, trigger the product-dev nightly against Altis 24 and confirm `composer install` succeeds.
- [ ] Manual: confirm local-server media upload works on this pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)