### PR TITLE
Fix MediaImportCest heading assertion for WordPress 7.0

### DIFF
--- a/tests/acceptance/MediaImportCest.php
+++ b/tests/acceptance/MediaImportCest.php
@@ -30,7 +30,7 @@ class MediaImportCest {
 		$I->amOnAdminPage( 'media-new.php' );
 
 		// Verify we're on the upload page.
-		$I->see( 'Upload New Media' );
+		$I->see( 'Upload Media' );
 
 		// Attach the test image file to the file input.
 		// The file is in the shared dev-tools/tests/_data directory.


### PR DESCRIPTION
## Summary

WordPress 7.0 changed the `media-new.php` page heading from **"Upload New Media"** to **"Upload Media"** (`wp-admin/media-new.php` now sets `$title = __( 'Upload Media' )`).

`MediaImportCest::mediaUploadWorks` still asserted the old string, so it failed at the first `see()` step before ever exercising the upload — even though media upload works correctly. This updates the assertion to match the new heading.

- Addresses: https://github.com/humanmade/product-dev/issues/2127

## Test plan

- `composer dev-tools codecept run -p vendor/altis/core/tests/` → `OK (2 tests, 27 assertions)` (previously `FAILURES! Tests: 2, Failures: 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)